### PR TITLE
tools/research: adopt research-note task generator + template (relocated from loops)

### DIFF
--- a/tools/research/new-research-task.mjs
+++ b/tools/research/new-research-task.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Stamp a research-note task .md for the loops orchestrator (pipelines/research-note.yaml
+// in the loops repo). This generator is a road-to-master domain asset; see
+// research-note-pipeline.md in this directory for the full workflow.
+//
+// Usage:
+//   node tools/research/new-research-task.mjs \
+//     --url https://example.org/paper.pdf \
+//     --concept "Attention Is All You Need" \
+//     --domain natural_language_processing \
+//     --out <loops>/prompts/<batch-name>
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const DOMAINS = new Set([
+  'natural_language_processing',
+  'computer_vision',
+  'recommender_system',
+  'timeseries',
+  'reinforcement_learning',
+  'mlops',
+  'utils',
+  'vision_language',
+]);
+
+const args = parseArgs(process.argv.slice(2));
+
+try {
+  const paperUrl = required(args.url, '--url');
+  const concept = required(args.concept, '--concept');
+  const domain = required(args.domain, '--domain');
+  const outDir = args.out || process.cwd();
+  const codeRepo = args['code-repo'] || '';
+
+  validateHttpsUrl(paperUrl, '--url');
+  if (codeRepo) validateHttpsUrl(codeRepo, '--code-repo');
+  if (!DOMAINS.has(domain)) {
+    throw new Error(`invalid --domain "${domain}". Expected one of: ${[...DOMAINS].join(', ')}`);
+  }
+
+  // Resolve the template beside this script so the generator works from any cwd.
+  const templatePath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'task-template.md');
+  const template = fs.readFileSync(templatePath, 'utf8');
+  const slug = kebabCase(concept);
+  const body = template
+    .replaceAll('[[paper_url]]', paperUrl)
+    .replaceAll('[[concept]]', concept)
+    .replaceAll('[[domain]]', domain)
+    .replaceAll('[[code_repo_url]]', codeRepo)
+    .replaceAll('[[expected_title]]', args['expected-title'] || 'unknown')
+    .replaceAll('[[expected_venue]]', args['expected-venue'] || 'unknown')
+    .replaceAll('[[expected_year]]', args['expected-year'] || 'unknown');
+
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, `${slug}.md`);
+  fs.writeFileSync(outPath, body, { flag: 'wx' });
+  console.log(outPath);
+} catch (error) {
+  console.error(error.message || error);
+  process.exit(1);
+}
+
+function parseArgs(argv) {
+  const parsed = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) throw new Error(`unexpected argument "${arg}"`);
+    const key = arg.slice(2);
+    const value = argv[i + 1];
+    if (!value || value.startsWith('--')) throw new Error(`missing value for ${arg}`);
+    parsed[key] = value;
+    i += 1;
+  }
+  return parsed;
+}
+
+function required(value, flag) {
+  if (!value || !String(value).trim()) throw new Error(`missing required ${flag}`);
+  return String(value).trim();
+}
+
+function validateHttpsUrl(value, flag) {
+  if (value.startsWith('-')) throw new Error(`${flag} must not start with '-'`);
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    throw new Error(`${flag} must be an absolute https:// URL`);
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`${flag} must be https-only; reject ext::, file://, git://, ssh://, http://, and user@host: transports`);
+  }
+}
+
+function kebabCase(value) {
+  const slug = value
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .replace(/-{2,}/g, '-');
+  if (!slug) throw new Error('--concept must contain at least one ASCII letter or digit for the task filename');
+  return slug;
+}

--- a/tools/research/research-note-pipeline.md
+++ b/tools/research/research-note-pipeline.md
@@ -1,0 +1,41 @@
+# Research Note Pipeline (loops orchestration)
+
+Research notes are produced by the loops orchestrator using `pipelines/research-note.yaml`
+(lives in the loops repo — pipelines are loops execution units). The domain assets live
+HERE in road-to-master: this generator, the task template, and the `make research-check`
+gate (`tools/research/check_note.py`).
+
+Stamp one task `.md` per paper with the generator, then run the batch through loops:
+
+```bash
+# from the road-to-master checkout
+node tools/research/new-research-task.mjs \
+  --url https://example.org/paper.pdf \
+  --concept "Attention Is All You Need" \
+  --domain natural_language_processing \
+  --out <loops>/prompts/<batch-name>
+
+# from the loops checkout
+make run DIR=<loops>/prompts/<batch-name> PIPELINE=pipelines/research-note.yaml CONCURRENCY=1
+```
+
+Required fields are `paper_url`, `concept`, and `domain`; `code_repo_url` is optional. The
+worker validates `paper_url`, and `code_repo_url` when present, as https-only before any
+fetch or clone, writes an evidence ledger, authors the note, and records `<domain>/<Topic>`
+in `.loop-manager/research-note-note-path`.
+
+Access-blocked papers (paywall/403/no full text): the worker first tries the arXiv preprint
+fallback (verified title+author match only). If no free full text exists, the run ends
+BLOCKED — no note of any kind is authored, `.loop-manager/research-note-blocked.json`
+records the observed facts, the note gate reports N/A, and the final phase files a tracking
+issue on this repo instead of publishing a note PR.
+
+The review phase is `Review: Research-Quality Gate`: first a deterministic command gate runs
+`make -C road-to-master research-check NOTE=<domain>/<Topic>`, then five independent
+reviewers run in parallel: ProvenanceCritic, TechnicalCorrectness,
+Readability&Demystification, Integration&StaticAnalysis, and CriticalEvaluation. R2 and R5
+fetch the paper full text themselves before judging. The final phase publishes one
+road-to-master PR (or the blocked-run tracking issue).
+
+Run research-note batches with `CONCURRENCY=1`. Domain README tables are shared files, so
+parallel notes can race on the same index.

--- a/tools/research/task-template.md
+++ b/tools/research/task-template.md
@@ -1,0 +1,69 @@
+# Research Note Task: [[concept]]
+
+## Input
+
+paper_url: [[paper_url]]
+concept: [[concept]]
+domain: [[domain]]
+code_repo_url: [[code_repo_url]]
+expected_title: [[expected_title]]
+expected_venue: [[expected_venue]]
+expected_year: [[expected_year]]
+
+## Worker Contract
+
+Validate input before any fetch or clone. `paper_url` and optional `code_repo_url` are
+https-only when present; an absent or blank `code_repo_url` means no code repository was
+provided and must not block the paper task. Reject ext::, file://, git://, ssh://,
+user@host:, http://, and any leading-`-` value. domain must be one of: natural_language_processing, computer_vision,
+recommender_system, timeseries, reinforcement_learning, mlops, utils, vision_language.
+
+Invoke the deep-research Skill methodology for evidence gathering: broaden source discovery,
+cross-check paper/project/venue metadata, and keep provenance in the ledger instead of relying
+on a single search result.
+
+Fetch/cache into an uncommitted cache dir OUTSIDE the note tree. Use `curl --proto '=https'`
+for paper fetches; abort PDF fetches over 50 MB; timeout is 30000 ms with 2 retries only for
+transient/timeout/5xx failures. HTTP 403 / 404 / 410 are non-retryable terminal outcomes with
+no retry storm: 404/410 -> FAIL as dead URL. On 403/paywall/no full text, first try the arXiv
+preprint fallback (query `https://export.arxiv.org/api/query` by exact title; accept only on
+normalized-title match plus author overlap; on a verified match author the normal note from
+the preprint with mandatory arXiv id+version provenance in the ledger). If no verified
+preprint exists, the run is BLOCKED: author NO note of any kind (no access-block record, no
+domain README row, no note-path file), write the observed facts to
+`.loop-manager/research-note-blocked.json`, leave every repo working tree clean, and stop.
+Never fabricate evidence from title-only access. See the pipeline's Worker Contract
+(`pipelines/research-note.yaml` in the loops repo) for the authoritative BLOCKED protocol.
+
+Run figure-backend preflight for `pdftoppm`, `pdfimages`, python `pymupdf`, and python
+`pdfplumber`. Figures are best-effort HTML-first from paper HTML/project page; process at most
+12 figures. If no backend exists and no HTML figures are available, record "figures unavailable
+(no extraction backend)" and continue text-only.
+
+If a code repository is linked, validate https-only first, then clone only to a temp dir with:
+`git -c protocol.ext.allow=never -c protocol.file.allow=never -c protocol.git.allow=never clone --depth=1 -- <url>`.
+Use static inspection only - never execute `make`, `pip`, `npm`, `python`, tests, hooks,
+binaries, package scripts, or cloned code. Skip clone over 500 MB as "too large". secret-scan
+before quoting. Set ledger `no_untrusted_code_executed: true`. There is NO override flag.
+
+Author `domains/<domain>/<Topic>/README.md` from `tools/research/templates/note.README.md` and
+create sibling `ledger.json`. Every Academic Context cell and non-trivial claim must have a
+ledger entry with kind exactly one of `paper-claim`, `evidence-supported`,
+`reasonable-inference`, or `unproven-or-doubtful`. Venue tier is literal `unknown` unless
+sourced. Citation count is literal `unavailable` on API 429/no-record, never `0`. A claim with
+no source_url cannot be `evidence-supported`.
+
+Write `## 🧪 Critical Assessment`. Interrogate problem realness, baseline/ablation/dataset/
+metric sufficiency, novelty-vs-repackaging, self-defined-benchmark / 射箭畫靶, and real-world
+relevance. Do not silently endorse or 背書 weak claims.
+
+Append the domain README Papers-table row `| Title | Venue | Year | Code | Review |`. Add only
+resolvable `../Related/` cross-links. If there is no related safe/resolvable note, keep the
+`## 🔗 Related notes` heading and leave the Related section empty; never invent a link. If the
+target folder already exists, SKIP/MERGE after inspecting it; never overwrite.
+
+Write the repo-relative note id `<domain>/<Topic>` to `.loop-manager/research-note-note-path`
+from the workspace container so the pipeline command can run:
+`make -C road-to-master research-check NOTE=<domain>/<Topic>`.
+Exception: a BLOCKED run writes `.loop-manager/research-note-blocked.json` instead and must
+NOT write the note-path file.


### PR DESCRIPTION
## What

Relocates the research-note **task generator + task template** from the loops repo into `tools/research/`, next to the rest of the research tooling (`check_note.py`, PR #90).

## Why

They are research-domain assets, not orchestrator infrastructure. In loops they were polluting:
- `scripts/` — every other script there is loops infra (status/retry/stop/watch/clean); this was the only domain-content generator
- `prompts/` — a gitignored runtime-artifact space that needed `.gitignore` carve-outs to commit domain content

The pipeline YAML itself stays in loops (`pipelines/research-note.yaml`, loops PR #88) — pipelines are loops execution units, consistent with existing domain pipelines there. Loops PR #88 removes the relocated files on its side.

## Changes vs the loops copies

- Generator resolves `task-template.md` beside itself via `import.meta.url` (was cwd-dependent `path.resolve('prompts/...')`)
- Template Worker Contract synced to the current pipeline contract: arXiv preprint fallback before BLOCKED; blocked runs author **no note** and write `research-note-blocked.json` instead of the note-path file
- `research-note-pipeline.md` documents the cross-repo workflow

## Validation

- `node --check` passes; smoke run from a foreign cwd stamps a task with the new BLOCKED contract; `ext::` URL rejected with a clear error
- No collision with PR #90 (adds `tools/research/README.md` etc.; filenames here are distinct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYLy53dT5RUWATXT7d4dDZ
