### PR TITLE
tools/research: paper-cache fetcher + deterministic ledger verifier + PDF snapshot tool

### DIFF
--- a/tools/research/fetch_paper.py
+++ b/tools/research/fetch_paper.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Fetch a paper ONCE into a shared cache dir for the research-note pipeline.
+
+The cache is consumed by the worker (all renew rounds) and reviewers (R2/R5) so
+that only ONE agent ever pays the discovery/fetch/extract cost. R1 keeps doing
+its own sampled live re-fetches by design (anti-fabrication) — this tool is not
+a substitute for that.
+
+Usage:
+  python3 tools/research/fetch_paper.py --url https://arxiv.org/abs/2304.02643 \
+      --out <WORKSPACE_DIR>/.loop-manager/paper-cache/<slug>
+
+Behavior:
+  - https-only validation (rejects ext::, file://, git://, ssh://, http://,
+    leading '-'). No override flag.
+  - arXiv URLs: fetches the PDF, the e-print LaTeX source (extracted under
+    source/), and the ar5iv HTML rendering. LaTeX is the PREFERRED provenance
+    representation for quotes and numeric claims.
+  - Non-arXiv URLs: fetches the URL as-is; a 403/challenge answer is reported
+    as exit 3 (access blocked) so the caller can run the arXiv-preprint
+    fallback / BLOCKED protocol.
+  - Extracts plain text from the PDF when a backend exists (pdftotext, then
+    pymupdf, then pdfplumber); records "unavailable" otherwise. With LaTeX
+    present this is optional.
+  - Writes meta.json: every artifact's source_url, sha256, byte size, HTTP
+    code, retrieved_at (UTC), extractor used. Reviewers verify cache
+    integrity against this.
+  - Re-running on a populated cache dir is a NO-OP (exit 0) unless --force.
+
+Exit codes: 0 ok / cache hit; 2 invalid input; 3 access blocked (403/paywall);
+4 fetch or extraction error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+CURL = [
+    "curl", "--proto", "=https", "--location", "--silent", "--show-error",
+    "--connect-timeout", "30", "--max-time", "120",
+    "--max-filesize", str(50 * 1024 * 1024),
+]
+
+ARXIV_RE = re.compile(
+    r"^https://(?:www\.)?arxiv\.org/(?:abs|pdf|e-print)/"
+    r"(?P<id>[0-9]{4}\.[0-9]{4,5}|[a-z-]+(?:\.[A-Z]{2})?/[0-9]{7})"
+    r"(?P<ver>v[0-9]+)?"
+)
+
+
+def die(code: int, msg: str) -> None:
+    print(f"fetch_paper: ERROR: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def validate_https(url: str) -> str:
+    if url.startswith("-"):
+        die(2, "url must not start with '-'")
+    if not url.startswith("https://"):
+        die(2, "url must be https:// (ext::, file://, git://, ssh://, http:// are rejected; no override)")
+    return url
+
+
+def sha256_of(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def curl_fetch(url: str, dest: Path):
+    """Fetch url to dest. Returns (http_code, content_type, error)."""
+    res = subprocess.run(
+        CURL + ["-o", str(dest), "-w", "%{http_code}\t%{content_type}", "--", url],
+        capture_output=True, text=True,
+    )
+    if res.returncode != 0:
+        return None, None, res.stderr.strip() or f"curl exit {res.returncode}"
+    parts = (res.stdout.split("\t") + ["", ""])[:2]
+    try:
+        return int(parts[0]), parts[1], None
+    except ValueError:
+        return None, parts[1], f"unparseable http code {parts[0]!r}"
+
+
+def extract_eprint(archive: Path, out_dir: Path) -> list[str]:
+    """Extract .tex/.bbl/.bib members from an arXiv e-print (tar.gz, gz, or raw tex)."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    extracted: list[str] = []
+    try:
+        with tarfile.open(archive, mode="r:*") as tar:
+            for member in tar.getmembers():
+                name = Path(member.name)
+                if member.isfile() and name.suffix in (".tex", ".bbl", ".bib") and ".." not in name.parts:
+                    target = out_dir / name.name
+                    with tar.extractfile(member) as src, target.open("wb") as dst:
+                        shutil.copyfileobj(src, dst)
+                    extracted.append(target.name)
+        return extracted
+    except tarfile.TarError:
+        pass
+    # Not a tar: maybe a gzipped (or raw) single .tex file.
+    import gzip
+    try:
+        data = gzip.decompress(archive.read_bytes())
+    except OSError:
+        data = archive.read_bytes()
+    if b"\\documentclass" in data[:4096] or b"\\begin{document}" in data:
+        target = out_dir / "main.tex"
+        target.write_bytes(data)
+        return [target.name]
+    return []
+
+
+def extract_pdf_text(pdf: Path, dest: Path) -> str:
+    """Try pdftotext -> pymupdf -> pdfplumber. Returns extractor name or 'unavailable'."""
+    if shutil.which("pdftotext"):
+        res = subprocess.run(["pdftotext", "-layout", str(pdf), str(dest)], capture_output=True)
+        if res.returncode == 0 and dest.exists():
+            return "pdftotext"
+    try:
+        import fitz  # pymupdf
+        with fitz.open(pdf) as doc:
+            dest.write_text("\n".join(page.get_text() for page in doc), encoding="utf-8")
+        return "pymupdf"
+    except Exception:
+        pass
+    try:
+        import pdfplumber
+        with pdfplumber.open(pdf) as doc:
+            dest.write_text(
+                "\n".join((page.extract_text() or "") for page in doc.pages), encoding="utf-8")
+        return "pdfplumber"
+    except Exception:
+        pass
+    return "unavailable"
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--url", required=True, help="paper url (https only)")
+    ap.add_argument("--out", required=True, help="cache dir, e.g. <WS>/.loop-manager/paper-cache/<slug>")
+    ap.add_argument("--force", action="store_true", help="re-fetch even if meta.json exists")
+    args = ap.parse_args()
+
+    url = validate_https(args.url.strip())
+    out = Path(args.out)
+    meta_path = out / "meta.json"
+    if meta_path.exists() and not args.force:
+        print(f"cache hit: {meta_path} exists — reuse it (pass --force to re-fetch)")
+        sys.exit(0)
+    out.mkdir(parents=True, exist_ok=True)
+
+    meta = {
+        "requested_url": url,
+        "retrieved_at": datetime.now(timezone.utc).isoformat(),
+        "artifacts": [],
+        "blocked": None,
+        "pdf_text_extractor": None,
+    }
+
+    def record(name: str, source_url: str, code, ctype):
+        p = out / name
+        meta["artifacts"].append({
+            "name": name, "source_url": source_url, "http_code": code,
+            "content_type": ctype, "sha256": sha256_of(p), "bytes": p.stat().st_size,
+        })
+
+    m = ARXIV_RE.match(url)
+    if m:
+        aid = m.group("id") + (m.group("ver") or "")
+        fetch_plan = [
+            ("paper.pdf", f"https://arxiv.org/pdf/{aid}"),
+            ("eprint.bin", f"https://arxiv.org/e-print/{aid}"),
+            ("ar5iv.html", f"https://ar5iv.labs.arxiv.org/html/{aid}"),
+        ]
+        meta["arxiv_id"] = aid
+        for name, src in fetch_plan:
+            code, ctype, err = curl_fetch(src, out / name)
+            if err or code is None:
+                if name == "paper.pdf":
+                    die(4, f"fetch failed for {src}: {err}")
+                print(f"warn: optional fetch failed for {src}: {err or code}", file=sys.stderr)
+                (out / name).unlink(missing_ok=True)
+                continue
+            if code == 403:
+                die(3, f"HTTP 403 from {src} — access blocked")
+            if code != 200:
+                if name == "paper.pdf":
+                    die(4, f"HTTP {code} from {src}")
+                (out / name).unlink(missing_ok=True)
+                continue
+            record(name, src, code, ctype)
+        eprint = out / "eprint.bin"
+        if eprint.exists():
+            texs = extract_eprint(eprint, out / "source")
+            meta["latex_sources"] = texs
+            if texs:
+                print(f"LaTeX source extracted: source/{{{', '.join(texs)}}} — PREFERRED provenance representation")
+    else:
+        code, ctype, err = curl_fetch(url, out / "paper.pdf")
+        if err or code is None:
+            die(4, f"fetch failed: {err}")
+        if code == 403:
+            meta["blocked"] = {"http_code": 403, "reason": "403 access block / paywall"}
+            meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+            die(3, "HTTP 403 — access blocked (meta.json written); run the arXiv-preprint fallback / BLOCKED protocol")
+        if code != 200:
+            die(4, f"HTTP {code}")
+        if ctype and "pdf" not in ctype:
+            (out / "paper.pdf").rename(out / "landing.html")
+            record("landing.html", url, code, ctype)
+            meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+            die(3, f"non-PDF answer ({ctype}) — likely landing page/paywall; inspect landing.html")
+        record("paper.pdf", url, code, ctype)
+
+    pdf = out / "paper.pdf"
+    if pdf.exists():
+        meta["pdf_text_extractor"] = extract_pdf_text(pdf, out / "paper.txt")
+        if meta["pdf_text_extractor"] != "unavailable":
+            record("paper.txt", "extracted-from:paper.pdf", None, "text/plain")
+
+    meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+    print(f"cache ready: {out} ({len(meta['artifacts'])} artifacts; extractor={meta['pdf_text_extractor']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/research/research-note-pipeline.md
+++ b/tools/research/research-note-pipeline.md
@@ -39,3 +39,32 @@ road-to-master PR (or the blocked-run tracking issue).
 
 Run research-note batches with `CONCURRENCY=1`. Domain README tables are shared files, so
 parallel notes can race on the same index.
+
+## Paper cache & tool-first verification (token efficiency)
+
+Every consumer used to re-run its own discovery → fetch → extract → verify loop
+(worker per renew round, R2/R5 per review round, R1's ad-hoc `verify-*.txt`
+scripts) — the same paper was re-acquired 4-5× per round. The tools here
+collapse that to ONE fetch and ONE deterministic verifier:
+
+| Tool | Job | Notes |
+|-|-|-|
+| `fetch_paper.py` | fetch ONCE into `<WS>/.loop-manager/paper-cache/<slug>/` | arXiv: PDF + e-print LaTeX (`source/*.tex`) + ar5iv HTML; `meta.json` records sha256/bytes/urls; idempotent (cache hit = no-op); 403 → exit 3 for the BLOCKED protocol |
+| `verify_ledger_snippets.py` | exact-substring check of every `quoted_snippet` vs the cache | EXACT / NORMALIZED (ws-collapse + tag-strip) / NOT_FOUND (exit 1); `--live` re-fetches non-cached https sources; worker pre-handoff self-check AND R1's first step |
+| `snapshot_pdf_region.py` | crop a PDF page region to PNG (table/figure evidence) | numeric claims verified by looking at ONE image; needs pymupdf, exits 5 gracefully without it — then quote the `.tex` table environment lines instead |
+
+Division of labor (deliberate):
+- **Worker** fetches once, authors from `source/*.tex` when present (LaTeX is the
+  preferred provenance representation — line wrapping and HTML markup in
+  PDF-extracted text / ar5iv cause false snippet mismatches), runs the verifier
+  before handing off, and fixes every NOT_FOUND first.
+- **R2/R5** read the cache (same bytes as the worker) — no re-fetch.
+- **R1** runs the verifier first, then spends judgment ONLY on what a tool cannot
+  decide: venue-tier sourcing, claim-kind labeling, and 2-3 sampled LIVE
+  re-fetches compared against `meta.json` sha256s (cache-poisoning check). R1's
+  independent live sampling is the anti-fabrication gate — never replace it
+  with the cache.
+
+These are agent-invoked tools referenced by the pipeline prompts — deliberately
+NOT wired as a pipeline `commands:` gate (a hard gate that needs network is the
+same failure class as the pre-#88 paywall gate crash).

--- a/tools/research/snapshot_pdf_region.py
+++ b/tools/research/snapshot_pdf_region.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Render a PDF page (or a region of it) to PNG — table/figure evidence snapshots.
+
+Numeric claims (benchmark tables, ablation numbers) burn the most review tokens
+when every verifier re-hunts them in full text. A cropped snapshot of the exact
+table lets a reviewer confirm the numbers by looking at ONE image. Store
+snapshots under the paper cache (e.g. paper-cache/<slug>/evidence/) and point
+the ledger entry at the snapshot path plus the .tex file:line.
+
+Usage:
+  python3 tools/research/snapshot_pdf_region.py --pdf paper.pdf --page 7 \
+      --out evidence/table4-lvis.png [--bbox x0,y0,x1,y1] [--zoom 2.0]
+
+--page is 1-based. --bbox is in PDF points (origin top-left, as reported by
+pymupdf); omit it to snapshot the whole page, then re-crop with a tighter bbox.
+
+Requires pymupdf. If it is not installed this tool exits 5 with a clear
+message — snapshots are best-effort evidence, like the figure backends; fall
+back to quoting the .tex table environment lines instead.
+
+Exit codes: 0 ok; 2 invalid input; 5 no renderer backend (pymupdf missing).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--pdf", required=True)
+    ap.add_argument("--page", required=True, type=int, help="1-based page number")
+    ap.add_argument("--out", required=True, help="output .png path")
+    ap.add_argument("--bbox", help="x0,y0,x1,y1 in PDF points; omit for full page")
+    ap.add_argument("--zoom", type=float, default=2.0, help="render scale (default 2.0)")
+    args = ap.parse_args()
+
+    try:
+        import fitz  # pymupdf
+    except ImportError:
+        print("snapshot_pdf_region: ERROR: pymupdf not installed — no PDF renderer on this box. "
+              "Fall back to quoting the .tex table/figure environment lines as evidence.",
+              file=sys.stderr)
+        sys.exit(5)
+
+    pdf = Path(args.pdf)
+    if not pdf.is_file():
+        print(f"snapshot_pdf_region: ERROR: no such pdf: {pdf}", file=sys.stderr)
+        sys.exit(2)
+
+    with fitz.open(pdf) as doc:
+        if not 1 <= args.page <= doc.page_count:
+            print(f"snapshot_pdf_region: ERROR: page {args.page} out of range 1..{doc.page_count}",
+                  file=sys.stderr)
+            sys.exit(2)
+        page = doc[args.page - 1]
+        clip = None
+        if args.bbox:
+            try:
+                x0, y0, x1, y1 = (float(v) for v in args.bbox.split(","))
+                clip = fitz.Rect(x0, y0, x1, y1)
+            except ValueError:
+                print("snapshot_pdf_region: ERROR: --bbox must be x0,y0,x1,y1", file=sys.stderr)
+                sys.exit(2)
+        mat = fitz.Matrix(args.zoom, args.zoom)
+        pix = page.get_pixmap(matrix=mat, clip=clip)
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        pix.save(out)
+        print(f"snapshot written: {out} ({pix.width}x{pix.height}px, page {args.page}"
+              f"{', bbox ' + args.bbox if args.bbox else ', full page'})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/research/task-template.md
+++ b/tools/research/task-template.md
@@ -22,9 +22,13 @@ Invoke the deep-research Skill methodology for evidence gathering: broaden sourc
 cross-check paper/project/venue metadata, and keep provenance in the ledger instead of relying
 on a single search result.
 
-Fetch/cache into an uncommitted cache dir OUTSIDE the note tree. Use `curl --proto '=https'`
-for paper fetches; abort PDF fetches over 50 MB; timeout is 30000 ms with 2 retries only for
-transient/timeout/5xx failures. HTTP 403 / 404 / 410 are non-retryable terminal outcomes with
+Fetch the paper ONCE with `python3 road-to-master/tools/research/fetch_paper.py --url <paper_url>
+--out <WORKSPACE_DIR>/.loop-manager/paper-cache/<slug>` and REUSE that cache on every later
+round (the tool is idempotent). Prefer the extracted `source/*.tex` for quotes and numeric
+values; run `tools/research/verify_ledger_snippets.py` as a pre-handoff self-check and fix
+every NOT_FOUND before finishing. Extra manual fetches stay inside the same cache dir with
+`curl --proto '=https'`; abort PDF fetches over 50 MB; timeout is 30000 ms with 2 retries only
+for transient/timeout/5xx failures. HTTP 403 / 404 / 410 are non-retryable terminal outcomes with
 no retry storm: 404/410 -> FAIL as dead URL. On 403/paywall/no full text, first try the arXiv
 preprint fallback (query `https://export.arxiv.org/api/query` by exact title; accept only on
 normalized-title match plus author overlap; on a verified match author the normal note from

--- a/tools/research/verify_ledger_snippets.py
+++ b/tools/research/verify_ledger_snippets.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Mechanically verify every ledger.json quoted_snippet against the paper cache.
+
+This replaces the per-round LLM-invented verification loops (ad-hoc verify-*.txt
+files, one-off Python one-liners) with ONE deterministic tool call. The worker
+runs it as a pre-handoff self-check; R1 (ProvenanceCritic) runs it FIRST and then
+spends its judgment only on what a tool cannot decide (venue-tier sourcing,
+claim-kind labeling, sampled LIVE re-fetches to detect cache poisoning).
+
+Usage:
+  python3 tools/research/verify_ledger_snippets.py \
+      --ledger road-to-master/domains/<domain>/<Topic>/ledger.json \
+      --cache  <WORKSPACE_DIR>/.loop-manager/paper-cache/<slug> [--live]
+
+Matching levels per entry (haystack = cached .tex/.txt/.html + entry-cited local
+file paths that exist):
+  EXACT       raw substring found
+  NORMALIZED  found after whitespace-collapse + HTML-tag-strip (acceptable; the
+              source's line wrapping / markup interrupts the raw bytes)
+  NOT_FOUND   nowhere in the corpus  -> exit 1 (fix the snippet or the citation)
+  LIVE_*      same, but matched only in a live re-fetch of source_url (--live)
+  SKIPPED_*   non-cached http source without --live / cited path no longer exists
+
+Exit codes: 0 all snippets EXACT/NORMALIZED (or skipped); 1 any NOT_FOUND;
+2 invalid input.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+CURL = [
+    "curl", "--proto", "=https", "--location", "--silent",
+    "--connect-timeout", "30", "--max-time", "60",
+    "--max-filesize", str(50 * 1024 * 1024),
+]
+
+TAG_RE = re.compile(r"<[^>]+>")
+WS_RE = re.compile(r"\s+")
+
+
+def normalize(text: str, strip_tags: bool) -> str:
+    if strip_tags:
+        text = TAG_RE.sub("", text)
+        text = html.unescape(text)
+    return WS_RE.sub(" ", text).strip()
+
+
+def load_corpus(cache: Path) -> dict[str, tuple[str, str]]:
+    """name -> (raw, normalized). Includes .tex/.txt/.html/.xml under the cache."""
+    corpus: dict[str, tuple[str, str]] = {}
+    if not cache.is_dir():
+        return corpus
+    for p in sorted(cache.rglob("*")):
+        if p.is_file() and p.suffix in (".tex", ".txt", ".html", ".xml", ".bbl", ".bib", ".md"):
+            raw = p.read_text(encoding="utf-8", errors="replace")
+            corpus[str(p.relative_to(cache))] = (raw, normalize(raw, strip_tags=p.suffix in (".html", ".xml")))
+    return corpus
+
+
+def match_level(snippet: str, raw: str, norm: str) -> str | None:
+    if snippet in raw:
+        return "EXACT"
+    if normalize(snippet, strip_tags=False) in norm:
+        return "NORMALIZED"
+    return None
+
+
+def live_fetch(url: str) -> str | None:
+    if not url.startswith("https://"):
+        return None
+    res = subprocess.run(CURL + ["--", url], capture_output=True, text=True)
+    return res.stdout if res.returncode == 0 and res.stdout else None
+
+
+def iter_entries(ledger):
+    """Yield (entry_id, source_url, quoted_snippet) from common ledger shapes."""
+    items = ledger.get("entries", ledger) if isinstance(ledger, dict) else ledger
+    if isinstance(items, dict):
+        for key, val in items.items():
+            if isinstance(val, dict):
+                yield key, val.get("source_url", ""), val.get("quoted_snippet", "")
+    elif isinstance(items, list):
+        for i, val in enumerate(items):
+            if isinstance(val, dict):
+                yield val.get("id", f"entry-{i}"), val.get("source_url", ""), val.get("quoted_snippet", "")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--ledger", required=True)
+    ap.add_argument("--cache", required=True)
+    ap.add_argument("--live", action="store_true", help="re-fetch non-cached https sources")
+    args = ap.parse_args()
+
+    ledger_path = Path(args.ledger)
+    if not ledger_path.is_file():
+        print(f"verify_ledger_snippets: ERROR: no ledger at {ledger_path}", file=sys.stderr)
+        sys.exit(2)
+    try:
+        ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        print(f"verify_ledger_snippets: ERROR: ledger is not valid JSON: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    corpus = load_corpus(Path(args.cache))
+    live_cache: dict[str, tuple[str, str] | None] = {}
+    results: list[tuple[str, str, str]] = []  # (entry, status, where)
+
+    for entry_id, source_url, snippet in iter_entries(ledger):
+        if not snippet:
+            continue
+        status, where = "NOT_FOUND", "-"
+        # 1) cached corpus
+        for name, (raw, norm) in corpus.items():
+            lvl = match_level(snippet, raw, norm)
+            if lvl:
+                status, where = lvl, name
+                break
+        # 2) a cited local file path (e.g. temp code clone)
+        if status == "NOT_FOUND" and source_url and not source_url.startswith("http"):
+            p = Path(source_url.split(":")[0]) if ":" in source_url else Path(source_url)
+            if p.is_file():
+                raw = p.read_text(encoding="utf-8", errors="replace")
+                lvl = match_level(snippet, raw, normalize(raw, strip_tags=False))
+                if lvl:
+                    status, where = lvl, str(p)
+            else:
+                status, where = "SKIPPED_MISSING_PATH", source_url
+        # 3) live re-fetch
+        if status == "NOT_FOUND" and source_url.startswith("https://"):
+            if args.live:
+                if source_url not in live_cache:
+                    body = live_fetch(source_url)
+                    live_cache[source_url] = (body, normalize(body, strip_tags=True)) if body else None
+                hit = live_cache[source_url]
+                if hit:
+                    lvl = match_level(snippet, hit[0], hit[1])
+                    if lvl:
+                        status, where = f"LIVE_{lvl}", source_url
+            elif not corpus:
+                status, where = "SKIPPED_LIVE", source_url
+        results.append((entry_id, status, where))
+
+    not_found = [r for r in results if r[1] == "NOT_FOUND"]
+    width = max((len(r[0]) for r in results), default=10)
+    for entry_id, status, where in results:
+        print(f"{entry_id:<{width}}  {status:<20}  {where}")
+    print(f"\nchecked={len(results)} exact={sum(1 for r in results if r[1]=='EXACT')} "
+          f"normalized={sum(1 for r in results if r[1]=='NORMALIZED')} "
+          f"live={sum(1 for r in results if r[1].startswith('LIVE'))} "
+          f"skipped={sum(1 for r in results if r[1].startswith('SKIPPED'))} "
+          f"NOT_FOUND={len(not_found)}")
+    sys.exit(1 if not_found else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Token-efficiency toolkit for the research-note pipeline. Motivated by measurement: the live SAM (Chinese) run burned **~3.1M tokens over 7 review rounds**, dominated by every agent re-running its own discovery→fetch→extract→verify loop (worker per renew round; R2/R5 per review round; R1 hand-writing 30+ `verify-*.txt` one-off scripts).

## Tools (all agent-invoked; deliberately NOT pipeline `commands:` gates)

| Tool | Job |
|-|-|
| `fetch_paper.py` | Fetch ONCE into `<WS>/.loop-manager/paper-cache/<slug>/`: PDF + arXiv e-print **LaTeX** (`source/*.tex`) + ar5iv HTML + `meta.json` (sha256/bytes/url per artifact). Idempotent (cache hit = no-op). https-only. 403 → exit 3 for the BLOCKED protocol. |
| `verify_ledger_snippets.py` | Deterministic exact-substring verification of every ledger `quoted_snippet` vs the cache: EXACT / NORMALIZED (ws-collapse+tag-strip) / NOT_FOUND (exit 1); `--live` for non-cached sources. Worker pre-handoff self-check AND R1's step 1. |
| `snapshot_pdf_region.py` | Crop a PDF page region to PNG so numeric table claims are verified by looking at ONE image; exits 5 gracefully without pymupdf (fall back to quoting the `.tex` table environment). |

Division of labor: worker fetches once + LaTeX-first authoring + self-check; R2/R5 read the cache (no re-fetch); **R1 keeps sampled LIVE re-fetches vs `meta.json` sha256s — the anti-cache-poisoning gate is not replaced by the cache.**

## Validation

- `py_compile` all tools (py3.9-compatible via `from __future__ import annotations`)
- `fetch_paper.py`: live smoke on arXiv 2304.02643 — PDF 15.6MB + LaTeX extracted (`segany.tex/.bbl`) + ar5iv + meta sha256s; idempotent re-run = no-op; `http://` rejected
- `verify_ledger_snippets.py`: run against the LIVE SAM run's real ledger+cache — 63 entries, 63 EXACT, exit 0 (and the same check class caught a real wrong-row citation earlier that round)
- `snapshot_pdf_region.py`: graceful exit 5 on this pymupdf-less box

Companion loops PR updates `pipelines/research-note.yaml` to reference these tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYLy53dT5RUWATXT7d4dDZ
