### PR TITLE
Add bilingual (EN default + zh-TW) versions for vision_language notes

### DIFF
--- a/domains/vision_language/Alpha-CLIP/README.md
+++ b/domains/vision_language/Alpha-CLIP/README.md
@@ -1,4 +1,5 @@
 # Alpha-CLIP — Research Note
+> **English** | [繁體中文](./README.zh-TW.md)
 
 ## 📇 Academic Context
 
@@ -11,68 +12,68 @@
 | Official Code | https://aleafy.github.io/alpha-clip |
 | Venue Kind | paper |
 
-> 本筆記依據 arXiv 版本（arXiv:2312.03818，LaTeX 原始檔即 CVPR 2024 投稿模板）撰寫；正式 camera-ready 版可能與此略有差異。所有數值與引文均以論文原文為準。
+> This note is written from the arXiv version (arXiv:2312.03818, whose LaTeX source is the CVPR 2024 submission template); the official camera-ready version may differ slightly. All numbers and quotations follow the paper's original text.
 
 ## First Principles
 
-### 從 CLIP 的盲點談起：為什麼要有 alpha 通道
+### Starting from CLIP's blind spot: why an alpha channel is needed
 
-原始 CLIP 以「整張圖 ↔ 整句描述」的對比學習取得對齊特徵，因此它天生把畫面裡所有物件的語意混在一起，無法只針對使用者指定的局部區域作答。過往的補救方式不外乎兩類：把感興趣區域裁切成獨立 patch，或把不相干像素／特徵遮成背景色——前者切斷了上下文，後者則直接改動了原圖內容。另一條路線（如 MaskCLIP）改用 attention mask 讓全域 `[CLS]` token 只關注局部，但它「只吐得出 `[CLS]` token」，因此無法接到需要整張 feature map 的下游模型（BLIP-2、LLaVA、Point-E）。Alpha-CLIP 的動機正是：在不破壞原圖、又能保留整張特徵圖的前提下，把「要看哪裡」這個提示塞進模型。
+The original CLIP obtains aligned features through "whole image ↔ whole caption" contrastive learning, so it inherently mixes the semantics of every object in the frame together and cannot answer with respect to only a user-specified local region. Past workarounds fall into two families: crop the region of interest into a standalone patch, or mask the irrelevant pixels/features to a background color — the former cuts off context, while the latter directly alters the original image content. Another line (e.g. MaskCLIP) instead uses an attention mask to make the global `[CLS]` token attend only to a local region, but it "can only emit a `[CLS]` token," and therefore cannot feed downstream models that need the entire feature map (BLIP-2, LLaVA, Point-E). Alpha-CLIP's motivation is exactly this: to inject the "where to look" hint into the model without corrupting the original image and while preserving the whole feature map.
 
-### 資料引擎：把 image-text 變成 RGBA region-text
+### Data engine: turning image-text into RGBA region-text
 
-要微調出能吃 alpha 通道的 CLIP，關鍵瓶頸是資料。作者設計了雙分支資料管線。第一條 grounding data pipeline 直接沿用 Kosmos-2 的 GRIT 資料集（GLIP 與 CLIP 自動標出 box 級的 region-text 配對），再用 SAM 為每個 box 產生高品質偽遮罩，升級成 mask 級配對；分類實驗即以此規模化到 GRIT-20m。這條分支保留了自然影像的完整背景，讓模型學會「在有上下文時聚焦」。
+To fine-tune a CLIP that can consume an alpha channel, the key bottleneck is data. The authors design a dual-branch data pipeline. The first, a grounding data pipeline, directly reuses Kosmos-2's GRIT dataset (GLIP and CLIP automatically label box-level region-text pairs), then uses SAM to produce high-quality pseudo-masks for each box, upgrading them into mask-level pairs; the classification experiments scale this up to GRIT-20m. This branch keeps the full background of natural images, teaching the model to "focus when there is context."
 
-第二條 classification data pipeline 針對物件中心（object-centric）情境：先用 SAM 對 ImageNet 每張圖生出數個遮罩，裁切、置中、放大前景後，用 CLIP 對該圖類別標籤打分並取高分遮罩；文字端則把前景放到純白背景再交給 BLIP-2 產生 caption，最後把 ImageNet 細類別標籤與 BLIP-2 caption 合併。作者最終從中挑出約 460k RGBA region-text pair，用於 REC、OVD、region captioning 與 2D/3D 生成等任務的訓練。
+The second, a classification data pipeline, targets object-centric scenarios: it first uses SAM to generate several masks for each ImageNet image, crops, centers, and enlarges the foreground, then scores each image against its class label with CLIP and takes the high-scoring masks; on the text side, it places the foreground on a pure white background and hands it to BLIP-2 to generate a caption, finally merging the ImageNet fine-grained class label with the BLIP-2 caption. From this the authors ultimately select about 460k RGBA region-text pairs, used to train tasks such as REC, OVD, region captioning, and 2D/3D generation.
 
-### 模型結構：與 RGB 卷積並行的零初始化 Alpha Conv
+### Model architecture: a zero-initialized Alpha Conv parallel to the RGB convolution
 
-結構改動刻意做得極小以保留 CLIP 先驗。ViT 影像編碼器第一層原本是一個大 kernel 的 RGB 卷積；作者在其旁邊「並排」加上一條 Alpha Conv，專門吃額外的 alpha 通道，輸入值域為 $[0,1]$（1 代表前景、0 代表背景）。最關鍵的技巧是把這條 Alpha Conv 的權重初始化為全零，使得訓練起點的 Alpha-CLIP 完全忽略 alpha 通道、行為等同原始 CLIP，之後再讓梯度慢慢學會利用這個新通道。訓練目標沿用 CLIP 的影像-文字對比損失（Info-NCE），其中 $\mathcal{V}$、$\mathcal{T}$ 為影像與文字編碼器、$\langle\cdot,\cdot\rangle$ 為餘弦相似度、$\tau$ 為溫度係數，標準形式如下式（符號整理為本筆記所加）：
+The architectural change is deliberately kept minimal to preserve the CLIP prior. The first layer of the ViT image encoder is originally a large-kernel RGB convolution; the authors add an Alpha Conv "side by side" next to it, dedicated to consuming the extra alpha channel, whose input range is $[0,1]$ (1 for foreground, 0 for background). The most crucial trick is to initialize this Alpha Conv's weights to all zeros, so that at the start of training Alpha-CLIP completely ignores the alpha channel and behaves identically to the original CLIP, after which gradients gradually learn to exploit this new channel. The training objective reuses CLIP's image-text contrastive loss (InfoNCE), where $\mathcal{V}$, $\mathcal{T}$ are the image and text encoders, $\langle\cdot,\cdot\rangle$ is cosine similarity, and $\tau$ is the temperature; the standard form is given below (the notation is added by this note):
 
 $$
 \mathcal{L}_{\text{InfoNCE}} = -\frac{1}{B}\sum_{m=1}^{B}\log\frac{\exp\!\big(\langle\mathcal{V}(x^{(m)}),\mathcal{T}(s^{(m)})\rangle/\tau\big)}{\sum_{n=1}^{B}\exp\!\big(\langle\mathcal{V}(x^{(m)}),\mathcal{T}(s^{(n)})\rangle/\tau\big)}
 $$
 
-### 訓練配方：凍結文字端、全解凍影像端
+### Training recipe: freeze the text side, fully unfreeze the image side
 
-訓練時文字編碼器全程凍結，只訓練影像編碼器，且對後續 transformer blocks 用比第一層 Alpha Conv 更低的學習率。為了不讓模型忘掉「看整張圖」的能力，作者用抽樣策略：以 $r_s=0.1$ 的比例把 RGBA-text 換回原始 image-text pair，並把 alpha 設為全 1。附錄的消融顯示：解凍全部 12 個 transformer block 效果最好（LoRA 反而較差），$r_s=0.1$ 為最佳點（不抽或抽太多都變差）。具體超參包含 batch size 4096、AdamW（weight decay 2e-2）、Alpha Conv 學習率 2e-4、其餘層 2e-6、cosine scheduler；GRIT-1m 訓練 6–8 個 epoch、GRIT-20m 訓練 2 個 epoch。
+During training the text encoder is frozen throughout and only the image encoder is trained, with a lower learning rate for the subsequent transformer blocks than for the first-layer Alpha Conv. To keep the model from forgetting how to "look at the whole image," the authors use a sampling strategy: with a ratio of $r_s=0.1$ they swap the RGBA-text back to the original image-text pair and set alpha to all ones. The appendix ablation shows that unfreezing all 12 transformer blocks works best (LoRA is worse), and $r_s=0.1$ is the sweet spot (neither no sampling nor too much sampling is as good). Concrete hyperparameters include batch size 4096, AdamW (weight decay 2e-2), Alpha Conv learning rate 2e-4, other layers 2e-6, a cosine scheduler; GRIT-1m is trained for 6–8 epochs and GRIT-20m for 2 epochs.
 
-![Alpha-CLIP 的資料生成管線與模型結構：(a) 產生數百萬 RGBA region-text pair，(b) 在第一層並排加入 Alpha Conv](imgs/method_overview.png)
+![Alpha-CLIP's data generation pipeline and model architecture: (a) generating millions of RGBA region-text pairs, (b) adding an Alpha Conv side by side in the first layer](imgs/method_overview.png)
 
-### 一次具體的前向：ImageNet-S 零樣本分類
+### One concrete forward pass: ImageNet-S zero-shot classification
 
-以 ViT-L/14 為例走一遍。輸入 224×224 影像，第一層卷積 kernel/stride 皆為 14，故切成 $224/14=16$，即 $16\times16=256$ 個 patch token 加上一個 `[CLS]` token。原本三通道 RGB 之外，我們把與前景遮罩對齊的 alpha map 也切成同樣 grid，經零初始化的 Alpha Conv 後加進 patch embedding。評測資料集 ImageNet-S 有 919 類且附帶語意分割標註，作者以「每類準確率的平均」為指標。當 alpha 給的是整張圖（全 1，等於沒有區域提示）時，ViT-L/14 的 top-1 為 73.37，與原始 CLIP 的 73.48 幾乎持平；換成矩形框 alpha 時升到 75.62；換成精細遮罩 alpha 時再升到 77.41。這條「無區域 → 框 → 遮罩」的遞增曲線，正是 alpha 通道確實把注意力導向前景的直接證據。
+Take ViT-L/14 and walk through it once. Given a 224×224 input image, the first-layer convolution has kernel/stride both 14, so it is split into $224/14=16$, i.e. $16\times16=256$ patch tokens plus one `[CLS]` token. Besides the three RGB channels, we also split the alpha map aligned with the foreground mask into the same grid, which after the zero-initialized Alpha Conv is added into the patch embedding. The evaluation dataset ImageNet-S has 919 classes with semantic segmentation annotations, and the authors use "the mean of per-class accuracy" as the metric. When the alpha given is the whole image (all ones, i.e. no region hint), ViT-L/14 reaches a top-1 of 73.37, almost on par with the original CLIP's 73.48; switching to a rectangular-box alpha raises it to 75.62; switching to a fine mask alpha raises it further to 77.41. This increasing curve of "no region → box → mask" is direct evidence that the alpha channel indeed steers attention toward the foreground.
 
-| Alpha Map（ViT-L/14） | Top-1 | Top-5 |
+| Alpha Map (ViT-L/14) | Top-1 | Top-5 |
 |-|-|-|
-| 原始 CLIP（無 alpha） | 73.48 | 91.60 |
-| whole image（全 1） | 73.37 | 91.75 |
+| Original CLIP (no alpha) | 73.48 | 91.60 |
+| whole image (all ones) | 73.37 | 91.75 |
 | rectangular box | 75.62 | 93.34 |
 | mask | 77.41 | 94.45 |
 
-### 從辨識延伸到下游：REC、OVD 與 MLLM/生成
+### From recognition to downstream: REC, OVD, and MLLM/generation
 
-同一個 Alpha-CLIP 可以即插即用地換掉各任務裡的 CLIP。在零樣本 REC（RefCOCO/＋/g）上，把 ReCLIP 流程中的 CLIP 換成 Alpha-CLIP，平均分別勝過 ReCLIP 與 Red Circle 6.8% 與 3.0%。在開放詞彙偵測（OV-LVIS）上，作者把 Detic 第二階段偽標註用的 ImageNet 換成自製的 MaskImageNet：僅用 460K 張圖就把 mAP_novel 從 Detic 基線的 24.6 推到 28.6（原始 CLIP 標註為 27.9），而 Detic 原本要用 1.2M 張——同時更準也更省資料。
+The same Alpha-CLIP can plug-and-play replace CLIP in various tasks. On zero-shot REC (RefCOCO/+/g), replacing the CLIP in the ReCLIP pipeline with Alpha-CLIP beats ReCLIP and Red Circle by 6.8% and 3.0% on average, respectively. On open-vocabulary detection (OV-LVIS), the authors replace the ImageNet used in Detic's second-stage pseudo-labeling with their own MaskImageNet: using only 460K images, they push mAP_novel from Detic's baseline 24.6 to 28.6 (original-CLIP labeling gives 27.9), whereas Detic originally used 1.2M images — more accurate and more data-efficient at once.
 
-在生成與多模態端，把 BLIP-2 / LLaVA-1.5 的視覺骨幹換成 Alpha-CLIP，即可用一筆劃或遮罩指定要描述的物件；量化上，Alpha-CLIP+LLaVA-1.5 在 region-level captioning 的 Visual Genome CIDEr 達 160.3，超過 GPT4RoI、GLaMM 等專用模型。2D（BLIP-Diffusion）與 3D（Point-E、PureCLIPNeRF）生成則主要以定性圖例展示可控聚焦與補齊缺件的效果。
+On the generation and multimodal side, replacing the visual backbone of BLIP-2 / LLaVA-1.5 with Alpha-CLIP lets one specify the object to describe with a single stroke or mask; quantitatively, Alpha-CLIP+LLaVA-1.5 reaches a Visual Genome CIDEr of 160.3 on region-level captioning, surpassing dedicated models such as GPT4RoI and GLaMM. 2D (BLIP-Diffusion) and 3D (Point-E, PureCLIPNeRF) generation are mainly shown through qualitative examples of controllable focus and completing missing parts.
 
 ## 🧪 Critical Assessment
 
-### 77.41 的頭條增益建立在資料集自帶的完美遮罩上
+### The headline 77.41 gain rests on the dataset's own perfect masks
 
-CLIP 對指定區域「看不準」是真實且被廣泛遇到的痛點，這點無庸置疑。但要留意頭條數字的成立條件：ImageNet-S 上 77.41 的成績是餵入**資料集自帶的 ground-truth 分割遮罩**當 alpha 得到的；換句話說，最亮眼的增益建立在「已經有一張近乎完美的前景遮罩」這個前提上，而真實部署時遮罩多半來自 SAM 等模型、品質不一。此外引言與摘要反覆宣稱「4.1% 的 top-1 提升」，但正文最終表格中 ViT-L/14 遮罩版是 77.41、原始 CLIP 是 73.48，實際只差 3.93 個百分點；4.1% 對應的是被更新掉的舊數字（77.58），這處內部不一致值得讀者自行核對。因此問題「在有好遮罩時被解決」較為穩妥，「在野外自動解決」則證據較弱。
+That CLIP "cannot look accurately" at a specified region is a real and widely encountered pain point, which is beyond doubt. But note the conditions under which the headline number holds: the 77.41 on ImageNet-S is obtained by feeding the **dataset's own ground-truth segmentation masks** as alpha; in other words, the most striking gain is built on the premise that "an almost perfect foreground mask is already available," whereas in real deployment masks mostly come from models like SAM and are of uneven quality. Moreover, the introduction and abstract repeatedly claim a "4.1% top-1 improvement," but in the final main table ViT-L/14 with masks is 77.41 and the original CLIP is 73.48, an actual difference of only 3.93 percentage points; the 4.1% corresponds to an outdated number that was later revised (77.58), an internal inconsistency worth the reader verifying. Thus "solved when a good mask is available" is the more defensible reading, while "solved automatically in the wild" is more weakly supported.
 
-### 自改的 MaskCLIP 基線與重訓 vs 免訓練的不對稱比較
+### The self-modified MaskCLIP baseline and the asymmetric retrain-vs-training-free comparison
 
-消融相當紮實：抽樣比例 $r_s$、解凍層數、資料量、LoRA vs 全微調都有系統性掃描，並用「只拿原始 image-text 全微調 CLIP 幾乎無增益」這個對照，說明增益來自 alpha 通道而非多看了資料——這是一個關鍵且到位的控制實驗。但比較的公平性有兩個保留點：其一，辨識任務的主要對手 MaskCLIP 是作者「做了必要修改」後才拿來比的自改基線，改動細節會影響其強弱；其二，Alpha-CLIP 需要在 GRIT-20m 這種規模上以數十張 A100 全參數微調，而 MaskCLIP 等對手是免訓練方法，這是一場「重訓練 vs 免訓練」的不對稱較量，準確率的絕對差距須連同其算力成本一起看。
+The ablation is quite solid: the sampling ratio $r_s$, number of unfrozen layers, data volume, and LoRA vs full fine-tuning are all systematically swept, and the control that "fully fine-tuning CLIP on the original image-text alone yields almost no gain" shows the gain comes from the alpha channel rather than from simply seeing more data — a key and well-placed control experiment. But there are two reservations about the fairness of the comparison: first, the main competitor on recognition, MaskCLIP, is a self-modified baseline the authors only used after "making necessary modifications," and those modification details affect its strength; second, Alpha-CLIP requires full-parameter fine-tuning at the GRIT-20m scale on dozens of A100s, whereas competitors like MaskCLIP are training-free methods — this is an asymmetric "retrain vs training-free" contest, and the absolute accuracy gap must be read together with its compute cost.
 
-### 簡單的通道注入靠資料引擎與廣度遷移撐起貢獻
+### A simple channel injection supported by the data engine and breadth of transfer
 
-核心手法——加一條輸入通道、零初始化、在 region-text 上微調——本身相當簡單，概念上更接近 vision-prompt / MaskCLIP 這條線的延伸而非全新機制。真正撐起貢獻分量的是兩件工程：一是用 SAM＋GRIT＋BLIP-2 把普通 image-text 自動轉成數百萬 RGBA region-text 的資料引擎，二是把同一顆模型 plug-and-play 地驗證到辨識、REC、OVD、MLLM 與 2D/3D 生成等橫跨感知與生成的廣度。把它評價為「一個被完整落地、遷移面極廣的簡單想法」較為中肯，而非理論上的突破。
+The core technique — adding one input channel, zero-initializing it, and fine-tuning on region-text — is itself fairly simple, conceptually closer to an extension of the vision-prompt / MaskCLIP line than a brand-new mechanism. What truly carries the weight of the contribution is two pieces of engineering: one is the data engine that uses SAM + GRIT + BLIP-2 to automatically turn ordinary image-text into millions of RGBA region-text pairs, and the other is plug-and-play validating the same model across recognition, REC, OVD, MLLM, and 2D/3D generation — a breadth spanning perception and generation. It is fairer to appraise it as "a simple idea that is thoroughly implemented and transfers extremely widely" than as a theoretical breakthrough.
 
-### 生成類宣稱多靠定性圖例、量化證據稀薄
+### The generation claims rely mostly on qualitative examples, with thin quantitative evidence
 
-辨識、REC、OVD、region captioning 都有硬指標支撐，可信度高；但 2D/3D 生成的優勢絕大多數靠精選圖例呈現，量化證據稀薄——3D 這塊僅附錄以 R-Precision 對 PureCLIPNeRF 做了少量比較，2D 影像變體幾乎沒有量化指標。加上方法在推論時仍依賴一張夠好的遮罩、且論文自承對過小物件會失焦，這些都限制了「隨手一劃就變好」的真實世界普適性。整體而言，把 Alpha-CLIP 當成「在能取得可靠遮罩的管線裡、可靠地提升區域聚焦」的實用元件是合理的，但對其生成類宣稱應保持審慎。
+Recognition, REC, OVD, and region captioning all have hard metrics behind them and are highly credible; but the advantages on 2D/3D generation are overwhelmingly shown through cherry-picked examples, with thin quantitative evidence — for 3D there is only a small appendix comparison against PureCLIPNeRF using R-Precision, and the 2D image variant has almost no quantitative metric. Add that the method at inference still depends on a good-enough mask, and the paper's own admission that it loses focus on very small objects, and these all limit the real-world generality of "just draw a stroke and it gets better." Overall, treating Alpha-CLIP as a practical component that "reliably improves regional focus within pipelines where reliable masks can be obtained" is reasonable, but one should stay cautious about its generation claims.
 
 ## 🔗 Related notes
 

--- a/domains/vision_language/Alpha-CLIP/README.zh-TW.md
+++ b/domains/vision_language/Alpha-CLIP/README.zh-TW.md
@@ -1,0 +1,80 @@
+# Alpha-CLIP — Research Note
+> [English](./README.md) | **繁體中文**
+
+## 📇 Academic Context
+
+| Field | Value |
+|-|-|
+| Title | Alpha-CLIP: A CLIP Model Focusing on Wherever You Want |
+| Venue | CVPR |
+| Year | 2024 |
+| Authors | Zeyi Sun, Ye Fang, Tong Wu, Pan Zhang, Yuhang Zang, Shu Kong, Yuanjun Xiong, Dahua Lin, Jiaqi Wang |
+| Official Code | https://aleafy.github.io/alpha-clip |
+| Venue Kind | paper |
+
+> 本筆記依據 arXiv 版本（arXiv:2312.03818，LaTeX 原始檔即 CVPR 2024 投稿模板）撰寫；正式 camera-ready 版可能與此略有差異。所有數值與引文均以論文原文為準。
+
+## First Principles
+
+### 從 CLIP 的盲點談起：為什麼要有 alpha 通道
+
+原始 CLIP 以「整張圖 ↔ 整句描述」的對比學習取得對齊特徵，因此它天生把畫面裡所有物件的語意混在一起，無法只針對使用者指定的局部區域作答。過往的補救方式不外乎兩類：把感興趣區域裁切成獨立 patch，或把不相干像素／特徵遮成背景色——前者切斷了上下文，後者則直接改動了原圖內容。另一條路線（如 MaskCLIP）改用 attention mask 讓全域 `[CLS]` token 只關注局部，但它「只吐得出 `[CLS]` token」，因此無法接到需要整張 feature map 的下游模型（BLIP-2、LLaVA、Point-E）。Alpha-CLIP 的動機正是：在不破壞原圖、又能保留整張特徵圖的前提下，把「要看哪裡」這個提示塞進模型。
+
+### 資料引擎：把 image-text 變成 RGBA region-text
+
+要微調出能吃 alpha 通道的 CLIP，關鍵瓶頸是資料。作者設計了雙分支資料管線。第一條 grounding data pipeline 直接沿用 Kosmos-2 的 GRIT 資料集（GLIP 與 CLIP 自動標出 box 級的 region-text 配對），再用 SAM 為每個 box 產生高品質偽遮罩，升級成 mask 級配對；分類實驗即以此規模化到 GRIT-20m。這條分支保留了自然影像的完整背景，讓模型學會「在有上下文時聚焦」。
+
+第二條 classification data pipeline 針對物件中心（object-centric）情境：先用 SAM 對 ImageNet 每張圖生出數個遮罩，裁切、置中、放大前景後，用 CLIP 對該圖類別標籤打分並取高分遮罩；文字端則把前景放到純白背景再交給 BLIP-2 產生 caption，最後把 ImageNet 細類別標籤與 BLIP-2 caption 合併。作者最終從中挑出約 460k RGBA region-text pair，用於 REC、OVD、region captioning 與 2D/3D 生成等任務的訓練。
+
+### 模型結構：與 RGB 卷積並行的零初始化 Alpha Conv
+
+結構改動刻意做得極小以保留 CLIP 先驗。ViT 影像編碼器第一層原本是一個大 kernel 的 RGB 卷積；作者在其旁邊「並排」加上一條 Alpha Conv，專門吃額外的 alpha 通道，輸入值域為 $[0,1]$（1 代表前景、0 代表背景）。最關鍵的技巧是把這條 Alpha Conv 的權重初始化為全零，使得訓練起點的 Alpha-CLIP 完全忽略 alpha 通道、行為等同原始 CLIP，之後再讓梯度慢慢學會利用這個新通道。訓練目標沿用 CLIP 的影像-文字對比損失（Info-NCE），其中 $\mathcal{V}$、$\mathcal{T}$ 為影像與文字編碼器、$\langle\cdot,\cdot\rangle$ 為餘弦相似度、$\tau$ 為溫度係數，標準形式如下式（符號整理為本筆記所加）：
+
+$$
+\mathcal{L}_{\text{InfoNCE}} = -\frac{1}{B}\sum_{m=1}^{B}\log\frac{\exp\!\big(\langle\mathcal{V}(x^{(m)}),\mathcal{T}(s^{(m)})\rangle/\tau\big)}{\sum_{n=1}^{B}\exp\!\big(\langle\mathcal{V}(x^{(m)}),\mathcal{T}(s^{(n)})\rangle/\tau\big)}
+$$
+
+### 訓練配方：凍結文字端、全解凍影像端
+
+訓練時文字編碼器全程凍結，只訓練影像編碼器，且對後續 transformer blocks 用比第一層 Alpha Conv 更低的學習率。為了不讓模型忘掉「看整張圖」的能力，作者用抽樣策略：以 $r_s=0.1$ 的比例把 RGBA-text 換回原始 image-text pair，並把 alpha 設為全 1。附錄的消融顯示：解凍全部 12 個 transformer block 效果最好（LoRA 反而較差），$r_s=0.1$ 為最佳點（不抽或抽太多都變差）。具體超參包含 batch size 4096、AdamW（weight decay 2e-2）、Alpha Conv 學習率 2e-4、其餘層 2e-6、cosine scheduler；GRIT-1m 訓練 6–8 個 epoch、GRIT-20m 訓練 2 個 epoch。
+
+![Alpha-CLIP 的資料生成管線與模型結構：(a) 產生數百萬 RGBA region-text pair，(b) 在第一層並排加入 Alpha Conv](imgs/method_overview.png)
+
+### 一次具體的前向：ImageNet-S 零樣本分類
+
+以 ViT-L/14 為例走一遍。輸入 224×224 影像，第一層卷積 kernel/stride 皆為 14，故切成 $224/14=16$，即 $16\times16=256$ 個 patch token 加上一個 `[CLS]` token。原本三通道 RGB 之外，我們把與前景遮罩對齊的 alpha map 也切成同樣 grid，經零初始化的 Alpha Conv 後加進 patch embedding。評測資料集 ImageNet-S 有 919 類且附帶語意分割標註，作者以「每類準確率的平均」為指標。當 alpha 給的是整張圖（全 1，等於沒有區域提示）時，ViT-L/14 的 top-1 為 73.37，與原始 CLIP 的 73.48 幾乎持平；換成矩形框 alpha 時升到 75.62；換成精細遮罩 alpha 時再升到 77.41。這條「無區域 → 框 → 遮罩」的遞增曲線，正是 alpha 通道確實把注意力導向前景的直接證據。
+
+| Alpha Map（ViT-L/14） | Top-1 | Top-5 |
+|-|-|-|
+| 原始 CLIP（無 alpha） | 73.48 | 91.60 |
+| whole image（全 1） | 73.37 | 91.75 |
+| rectangular box | 75.62 | 93.34 |
+| mask | 77.41 | 94.45 |
+
+### 從辨識延伸到下游：REC、OVD 與 MLLM/生成
+
+同一個 Alpha-CLIP 可以即插即用地換掉各任務裡的 CLIP。在零樣本 REC（RefCOCO/＋/g）上，把 ReCLIP 流程中的 CLIP 換成 Alpha-CLIP，平均分別勝過 ReCLIP 與 Red Circle 6.8% 與 3.0%。在開放詞彙偵測（OV-LVIS）上，作者把 Detic 第二階段偽標註用的 ImageNet 換成自製的 MaskImageNet：僅用 460K 張圖就把 mAP_novel 從 Detic 基線的 24.6 推到 28.6（原始 CLIP 標註為 27.9），而 Detic 原本要用 1.2M 張——同時更準也更省資料。
+
+在生成與多模態端，把 BLIP-2 / LLaVA-1.5 的視覺骨幹換成 Alpha-CLIP，即可用一筆劃或遮罩指定要描述的物件；量化上，Alpha-CLIP+LLaVA-1.5 在 region-level captioning 的 Visual Genome CIDEr 達 160.3，超過 GPT4RoI、GLaMM 等專用模型。2D（BLIP-Diffusion）與 3D（Point-E、PureCLIPNeRF）生成則主要以定性圖例展示可控聚焦與補齊缺件的效果。
+
+## 🧪 Critical Assessment
+
+### 77.41 的頭條增益建立在資料集自帶的完美遮罩上
+
+CLIP 對指定區域「看不準」是真實且被廣泛遇到的痛點，這點無庸置疑。但要留意頭條數字的成立條件：ImageNet-S 上 77.41 的成績是餵入**資料集自帶的 ground-truth 分割遮罩**當 alpha 得到的；換句話說，最亮眼的增益建立在「已經有一張近乎完美的前景遮罩」這個前提上，而真實部署時遮罩多半來自 SAM 等模型、品質不一。此外引言與摘要反覆宣稱「4.1% 的 top-1 提升」，但正文最終表格中 ViT-L/14 遮罩版是 77.41、原始 CLIP 是 73.48，實際只差 3.93 個百分點；4.1% 對應的是被更新掉的舊數字（77.58），這處內部不一致值得讀者自行核對。因此問題「在有好遮罩時被解決」較為穩妥，「在野外自動解決」則證據較弱。
+
+### 自改的 MaskCLIP 基線與重訓 vs 免訓練的不對稱比較
+
+消融相當紮實：抽樣比例 $r_s$、解凍層數、資料量、LoRA vs 全微調都有系統性掃描，並用「只拿原始 image-text 全微調 CLIP 幾乎無增益」這個對照，說明增益來自 alpha 通道而非多看了資料——這是一個關鍵且到位的控制實驗。但比較的公平性有兩個保留點：其一，辨識任務的主要對手 MaskCLIP 是作者「做了必要修改」後才拿來比的自改基線，改動細節會影響其強弱；其二，Alpha-CLIP 需要在 GRIT-20m 這種規模上以數十張 A100 全參數微調，而 MaskCLIP 等對手是免訓練方法，這是一場「重訓練 vs 免訓練」的不對稱較量，準確率的絕對差距須連同其算力成本一起看。
+
+### 簡單的通道注入靠資料引擎與廣度遷移撐起貢獻
+
+核心手法——加一條輸入通道、零初始化、在 region-text 上微調——本身相當簡單，概念上更接近 vision-prompt / MaskCLIP 這條線的延伸而非全新機制。真正撐起貢獻分量的是兩件工程：一是用 SAM＋GRIT＋BLIP-2 把普通 image-text 自動轉成數百萬 RGBA region-text 的資料引擎，二是把同一顆模型 plug-and-play 地驗證到辨識、REC、OVD、MLLM 與 2D/3D 生成等橫跨感知與生成的廣度。把它評價為「一個被完整落地、遷移面極廣的簡單想法」較為中肯，而非理論上的突破。
+
+### 生成類宣稱多靠定性圖例、量化證據稀薄
+
+辨識、REC、OVD、region captioning 都有硬指標支撐，可信度高；但 2D/3D 生成的優勢絕大多數靠精選圖例呈現，量化證據稀薄——3D 這塊僅附錄以 R-Precision 對 PureCLIPNeRF 做了少量比較，2D 影像變體幾乎沒有量化指標。加上方法在推論時仍依賴一張夠好的遮罩、且論文自承對過小物件會失焦，這些都限制了「隨手一劃就變好」的真實世界普適性。整體而言，把 Alpha-CLIP 當成「在能取得可靠遮罩的管線裡、可靠地提升區域聚焦」的實用元件是合理的，但對其生成類宣稱應保持審慎。
+
+## 🔗 Related notes
+
+- [Stable Diffusion](../stable-diffusion/)

--- a/domains/vision_language/LLaVA-Med/README.md
+++ b/domains/vision_language/LLaVA-Med/README.md
@@ -1,4 +1,5 @@
 # LLaVA-Med — Research Note
+> **English** | [繁體中文](./README.zh-TW.md)
 
 ## 📇 Academic Context
 
@@ -13,34 +14,34 @@
 
 ## First Principles
 
-通用領域的大型多模態模型（large multimodal model, LMM）如 LLaVA 依賴網路上的一般影像—文字配對訓練，面對生物醫學影像時往往表現得像門外漢（layperson），會拒答、給出錯誤回應甚至整段幻覺。LLaVA-Med 的核心命題就是：用可負擔的成本，把一個現成的通用 LMM 適配（adapt）成能對生物醫學影像做開放式問答的對話助手，而不是從頭訓練或做傳統的分類式 VQA。
+General-domain large multimodal models (LMMs) such as LLaVA are trained on generic web image-text pairs, and when facing biomedical images they often behave like a layperson — refusing to answer, giving wrong responses, or even hallucinating entire passages. LLaVA-Med's core thesis is exactly this: to adapt an off-the-shelf general LMM into a conversational assistant capable of open-ended question answering over biomedical images at an affordable cost, rather than training from scratch or doing traditional classification-style VQA.
 
-整個方法的關鍵不是新網路，而是一條資料引擎。作者從 PubMed Central 萃取的大規模圖說資料集 PMC-15M（1500 萬組生物醫學影像—文字配對）取樣，再用 language-only GPT-4 只根據文字（圖說 caption 以及原文中提及該圖的句子 citances）自我生成（self-instruct）指令跟隨資料。GPT-4 全程看不到影像，只被要求用「彷彿看得到圖」的語氣產生多輪問答，因此整條流程零人工標註。
+The key of the whole method is not a new network but a data engine. The authors sample from PMC-15M — a large-scale figure-caption dataset (15 million biomedical image-text pairs) extracted from PubMed Central — and then use language-only GPT-4 to self-instruct instruction-following data based solely on the text (the figure caption plus the sentences in the source article that mention the figure, i.e. citances). GPT-4 never sees the image throughout, and is only asked to produce multi-turn Q&A in a tone "as if it could see the figure," so the entire pipeline requires zero human annotation.
 
-第一階段用的概念對齊資料，是把 600K 從 PMC-15M 取樣的影像—文字對，用最樸素的擴充法轉成指令：指令只要求「描述這張圖」，而目標輸出就是原始的 caption。依 caption 長度在「簡短描述」與「詳細描述」兩組問句之間切換，以 30 詞為分界（PMC-15M 中約 25% 的 caption 少於 30 詞）。這一階段只涵蓋單一任務（影像描述），目的在鋪滿生物醫學概念的覆蓋面。
+The concept-alignment data used in the first stage turns 600K image-text pairs sampled from PMC-15M into instructions using the most naive expansion: the instruction only asks to "describe this image," and the target output is the original caption. It switches between a "concise description" and a "detailed description" set of prompts by caption length, using 30 words as the cutoff (about 25% of PMC-15M captions have fewer than 30 words). This stage covers only a single task (image description), aiming to blanket the coverage of biomedical concepts.
 
-第二階段用的指令微調資料，則先篩掉多子圖、只保留單一子圖的影像，再從 CXR（胸部 X 光）、CT、MRI、histopathology、gross pathology 這五種最常見模態取樣 60K 組，用 GPT-4 生成多輪問答，並把 PubMed 原文中提及該圖的句子（inline mentions, IM）當作額外脈絡。作者刻意做了三個版本——10K、60K、60K-IM——以消融資料生成策略對下游模型的影響。
+The instruction-tuning data used in the second stage first filters out multi-subfigure images and keeps only single-subfigure ones, then samples 60K pairs from the five most common modalities — CXR (chest X-ray), CT, MRI, histopathology, gross pathology — uses GPT-4 to generate multi-turn Q&A, and treats the sentences that mention the figure in the source PubMed article (inline mentions, IM) as additional context. The authors deliberately make three versions — 10K, 60K, 60K-IM — to ablate the impact of the data generation strategy on the downstream model.
 
-每一筆對齊樣本被組織成單輪的指令跟隨格式，其中 $\Xmat_{\texttt{q}}$ 是取樣到的描述指令、$\Xmat_{\texttt{v}}$ 是影像、$\Xmat_{\texttt{c}}$ 是作為目標輸出的 caption：
+Each alignment sample is organized into a single-turn instruction-following format, where $\Xmat_{\texttt{q}}$ is the sampled description instruction, $\Xmat_{\texttt{v}}$ is the image, and $\Xmat_{\texttt{c}}$ is the caption used as the target output:
 
 ```
 Human : X_q  X_v  <STOP>\n
 Assistant : X_c  <STOP>\n
 ```
 
-模型結構直接沿用 LLaVA：一個視覺編碼器、一個線性投影層、一個語言模型。訓練採兩階段課程學習（curriculum learning）。Stage 1（生物醫學概念特徵對齊）同時凍結視覺編碼器與語言模型，只更新投影矩陣，把大量新的生物醫學視覺概念對齊到語言模型既有的詞嵌入；Stage 2（端到端指令微調）只凍結視覺編碼器，同時更新投影層與語言模型的權重，讓模型學會開放式對話語義。作者把這個過程類比成一個外行人逐步被訓練成專業助手。
+The model architecture directly follows LLaVA: a vision encoder, a linear projection layer, and a language model. Training uses a two-stage curriculum learning. Stage 1 (biomedical concept feature alignment) freezes both the vision encoder and the language model and updates only the projection matrix, aligning a large number of new biomedical visual concepts to the language model's existing word embeddings; Stage 2 (end-to-end instruction tuning) freezes only the vision encoder and updates both the projection layer and the language model weights, letting the model learn open-ended conversational semantics. The authors analogize this process to a layperson gradually being trained into a professional assistant.
 
-![圖 3：LLaVA-Med 兩階段課程學習訓練流程示意](imgs/training_pipeline.png)
+![Figure 3: schematic of LLaVA-Med's two-stage curriculum-learning training pipeline](imgs/training_pipeline.png)
 
-這套配方主打「可負擔」：Stage 1 與 Stage 2 分別約 7 與 8 小時、合計不到 15 小時，跑在 8 張 40G A100 GPU 上，這也是標題「in One Day」的由來。作者提供了各階段、各 epoch 的實際耗時，讓使用者能自行做成本—品質取捨：
+This recipe emphasizes "affordability": Stage 1 and Stage 2 take about 7 and 8 hours respectively, totaling under 15 hours, running on 8× 40G A100 GPUs, which is the origin of the title "in One Day." The authors provide the actual wall-clock time for each stage and epoch, letting users make their own cost-quality trade-offs:
 
-| 階段 / epoch | Stage 1 (1 ep) | Stage 1 (3 ep) | Stage 2 10K (1 ep) | Stage 2 10K (3 ep) | Stage 2 60K (1 ep) | Stage 2 60K (3 ep) |
+| Stage / epoch | Stage 1 (1 ep) | Stage 1 (3 ep) | Stage 2 10K (1 ep) | Stage 2 10K (3 ep) | Stage 2 60K (1 ep) | Stage 2 60K (3 ep) |
 |-|-|-|-|-|-|-|
-| 時間（小時） | 6.8 | 19.4 | 0.6 | 1.8 | 2.6 | 8.0 |
+| Time (hours) | 6.8 | 19.4 | 0.6 | 1.8 | 2.6 | 8.0 |
 
-評估分成兩條軸線。第一條是開放式視覺對話：作者構建 193 題全新問題（143 題 conversation 加 50 題 detailed description），用 language-only GPT-4 當裁判，對候選模型與 GPT-4 參考答案在有用性、相關性、正確性、細節程度上評分，再以 GPT-4 的參考分數正規化算出相對分數（relative score）。下表是各設定在這 193 題上的整體相對分數：
+Evaluation is split into two axes. The first is open-ended visual conversation: the authors construct 193 brand-new questions (143 conversation plus 50 detailed description), use language-only GPT-4 as a judge to score candidate models and the GPT-4 reference answers on helpfulness, relevance, accuracy, and level of detail, and then compute a relative score normalized by GPT-4's reference score. The table below gives the overall relative scores on these 193 questions for each setting:
 
-| 模型設定 | Conversation | Description | Overall |
+| Model setting | Conversation | Description | Overall |
 |-|-|-|-|
 | LLaVA | 39.4 | 26.2 | 36.1 |
 | LLaVA-Med Stage 1 | 22.6 | 25.2 | 23.3 |
@@ -48,34 +49,34 @@ Assistant : X_c  <STOP>\n
 | LLaVA-Med 60K | 53.7 | 36.9 | 49.4 |
 | LLaVA-Med 60K-IM | 55.1 | 36.4 | 50.2 |
 
-走一遍實際數字更能看清課程學習的作用：通用 LLaVA 的整體相對分數是 36.1；只做 Stage 1 反而掉到 23.3，因為單一的影像描述指令讓模型喪失跟隨多樣指令的能力；補上 Stage 2 指令資料後，10K→60K→60K-IM 分別回升到 39.9、49.4、50.2，最佳的 60K-IM 版本達到 GPT-4 參考上限的 50.2%。這條曲線同時說明兩件事：Stage 1 單獨不足以當聊天機器人，而指令資料量與 inline mentions 都對品質有正貢獻。
+Walking through the actual numbers makes the effect of curriculum learning clearer: general LLaVA has an overall relative score of 36.1; doing only Stage 1 actually drops to 23.3, because the single image-description instruction makes the model lose the ability to follow diverse instructions; after adding the Stage 2 instruction data, 10K→60K→60K-IM rise back to 39.9, 49.4, 50.2 respectively, with the best 60K-IM version reaching 50.2% of the GPT-4 reference ceiling. This curve illustrates two things at once: Stage 1 alone is insufficient to be a chatbot, and both instruction-data volume and inline mentions contribute positively to quality.
 
-第二條軸線是三個既有的生物醫學 VQA 基準：VQA-RAD、SLAKE、PathVQA。封閉式問題報 accuracy、開放式問題報 recall（因為 LLaVA-Med 以自由文字生成作答，而非從候選集挑選）。下表節錄下游微調後與過往 supervised SoTA 的比較（closed-set accuracy）：
+The second axis is three existing biomedical VQA benchmarks: VQA-RAD, SLAKE, PathVQA. Closed-set questions report accuracy and open-set questions report recall (because LLaVA-Med answers by free-text generation rather than selecting from a candidate set). The table below excerpts the comparison against prior supervised SoTA after downstream fine-tuning (closed-set accuracy):
 
-| 方法 | VQA-RAD Closed | SLAKE Closed | PathVQA Closed |
+| Method | VQA-RAD Closed | SLAKE Closed | PathVQA Closed |
 |-|-|-|-|
 | LLaVA | 65.07 | 63.22 | 63.20 |
 | LLaVA-Med (From LLaVA) | 84.19 | 85.34 | 91.21 |
 | LLaVA-Med (BioMed CLIP) | 83.09 | 86.78 | 91.09 |
 | M2I2 | 83.50 | 91.10 | 88.00 |
 
-經下游微調後，LLaVA-Med 在 VQA-RAD 與 PathVQA 的封閉式問題上刷新了 supervised SoTA（VQA-RAD closed 84.19、PathVQA closed 91.21），驗證了只要指令夠明確（例如是非題），模型就能可靠地依指令完成生物醫學任務。
+After downstream fine-tuning, LLaVA-Med sets new supervised SoTA on the closed-set questions of VQA-RAD and PathVQA (VQA-RAD closed 84.19, PathVQA closed 91.21), verifying that as long as the instruction is precise enough (e.g. a yes/no question), the model can reliably complete biomedical tasks by following the instruction.
 
-但在開放式問題上，LLaVA-Med 只在 SLAKE 上取得 SoTA，在其餘資料集上的表現受限、甚至落後既有方法；作者把原因歸給開放式生物醫學問題在不限定候選答案時本就語意模糊。這個誠實的自陳，正好標示出這條路徑的邊界。
+But on open-set questions, LLaVA-Med only achieves SoTA on SLAKE and is limited or even lags existing methods on the other datasets; the authors attribute the reason to open-ended biomedical questions being inherently semantically ambiguous when the candidate answers are not restricted. This honest self-assessment marks precisely the boundary of this line of approach.
 
 ## 🧪 Critical Assessment
 
-### 醫學影像上的幻覺是安全風險，不只是品質瑕疵
-問題本身是真的：通用 LMM 在醫學影像上會像門外漢般幻覺，這在臨床脈絡下不只是品質瑕疵，而是安全風險。作者在結論也坦承 LLaVA-Med 仍受幻覺與淺層推理（weak in-depth reasoning）所限。把「領域適配」而非「更大模型」當成核心命題，對高價值但資料稀缺的垂直領域是合理且務實的切入點。
+### Hallucination on medical images is a safety risk, not just a quality flaw
+The problem itself is real: general LMMs hallucinate like a layperson on medical images, which in a clinical context is not just a quality flaw but a safety risk. The authors also admit in the conclusion that LLaVA-Med is still limited by hallucination and weak in-depth reasoning. Taking "domain adaptation" rather than "a larger model" as the core thesis is a reasonable and pragmatic entry point for high-value but data-scarce vertical domains.
 
-### GPT-4 既是出題者也是閱卷者：循環評估的風險
-消融相當紮實：Table 3(b) 系統性地掃過 Stage 1/2 與下游微調的 epoch 數、7B vs 13B 語言模型、CLIP vs BioMedCLIP 視覺編碼器，並附上 running time 供成本—品質取捨。真正的隱憂在指標：聊天品質的主指標是 GPT-4 自評的 relative score，而訓練資料也由 GPT-4 生成——同一個模型家族既當出題者又當閱卷者，存在循環評估（circular evaluation）的偏誤風險，數字漂亮未必等於獨立的臨床效度。
+### GPT-4 is both examiner and grader: the risk of circular evaluation
+The ablation is quite solid: Table 3(b) systematically sweeps the number of epochs for Stage 1/2 and downstream fine-tuning, 7B vs 13B language models, and CLIP vs BioMedCLIP vision encoders, and attaches running time for cost-quality trade-offs. The real concern lies in the metric: the main metric for chat quality is a GPT-4 self-assessed relative score, while the training data is also generated by GPT-4 — the same model family is both examiner and grader, which carries the bias risk of circular evaluation, and a pretty number does not necessarily equal independent clinical validity.
 
-### 新意在「圖說→指令」的資料配方與兩階段課程，而非架構
-就元件而言，LLaVA-Med 幾乎全用既有積木：LLaVA 架構、GPT-4 self-instruct、PMC-15M 資料、可選的 Vicuna 或 BioMedCLIP 初始化。真正的新意集中在「圖說→指令」的資料生成配方與兩階段課程，較接近把一套成熟配方成功遷移到高價值垂直領域，而非架構層級的創新。持平地說，其資料集與流程的開源、以及低到「一天內」的訓練成本本身，就是有實用價值的貢獻，不宜只以「重組」一筆帶過。
+### The novelty lies in the "caption→instruction" data recipe and the two-stage curriculum, not the architecture
+In terms of components, LLaVA-Med almost entirely uses existing building blocks: the LLaVA architecture, GPT-4 self-instruct, PMC-15M data, and optional Vicuna or BioMedCLIP initialization. The real novelty concentrates in the "caption→instruction" data generation recipe and the two-stage curriculum, closer to successfully transferring a mature recipe to a high-value vertical domain than to an architecture-level innovation. In fairness, open-sourcing its dataset and pipeline, together with the training cost being as low as "within one day," is itself a contribution of practical value and should not be dismissed as mere "recombination."
 
-### 封閉式刷新 SoTA、開放式仍落後：能力邊界與 193 題基準的自我耦合
-「解決了嗎」必須分開看。封閉式 VQA 刷新 SoTA，本質是把是非/選擇題用生成式模型答對；而更貼近真實臨床提問的開放式問題，LLaVA-Med 反而多半落後既有方法，顯示開放式生物醫學理解遠未被解決。此外，193 題的視覺對話基準是作者用與訓練資料同一條 self-instruct 管線生成的，基準的定義與模型的強項高度耦合，且 GPT-4 參考答案吃到 golden caption 與 inline mentions、並非對影像的真實理解，使聊天分數更像內部一致性而非臨床效度。評估也未涉及真實部署、標註者一致性或安全稽核。因此本文更適合被理解為一個可負擔的領域適配「配方與資料資產」，而非臨床可用的成品系統。
+### Closed-set sets new SoTA, open-set still lags: the capability boundary and the self-coupling of the 193-question benchmark
+"Is it solved" must be examined separately. Closed-set VQA sets new SoTA, which in essence is answering yes/no and multiple-choice questions correctly with a generative model; whereas on open-set questions, which are closer to real clinical inquiries, LLaVA-Med mostly lags existing methods, showing that open-ended biomedical understanding is far from solved. Moreover, the 193-question visual conversation benchmark is generated by the authors with the same self-instruct pipeline as the training data, so the benchmark's definition is highly coupled to the model's strengths, and the GPT-4 reference answers consume the golden caption and inline mentions rather than a true understanding of the image, making the chat scores more like internal consistency than clinical validity. The evaluation also does not touch real deployment, annotator agreement, or safety audits. Therefore this paper is better understood as an affordable domain-adaptation "recipe and data asset" than a clinically usable finished system.
 
 ## 🔗 Related notes
 

--- a/domains/vision_language/LLaVA-Med/README.zh-TW.md
+++ b/domains/vision_language/LLaVA-Med/README.zh-TW.md
@@ -1,0 +1,83 @@
+# LLaVA-Med — Research Note
+> [English](./README.md) | **繁體中文**
+
+## 📇 Academic Context
+
+| Field | Value |
+|-|-|
+| Title | LLaVA-Med: Training a Large Language-and-Vision Assistant for Biomedicine in One Day |
+| Venue | NeurIPS 2023 (Datasets and Benchmarks Track) |
+| Year | 2023 |
+| Authors | Chunyuan Li, Cliff Wong, Sheng Zhang, Naoto Usuyama, Haotian Liu, Jianwei Yang, Tristan Naumann, Hoifung Poon, Jianfeng Gao |
+| Official Code | https://github.com/microsoft/LLaVA-Med |
+| Venue Kind | paper |
+
+## First Principles
+
+通用領域的大型多模態模型（large multimodal model, LMM）如 LLaVA 依賴網路上的一般影像—文字配對訓練，面對生物醫學影像時往往表現得像門外漢（layperson），會拒答、給出錯誤回應甚至整段幻覺。LLaVA-Med 的核心命題就是：用可負擔的成本，把一個現成的通用 LMM 適配（adapt）成能對生物醫學影像做開放式問答的對話助手，而不是從頭訓練或做傳統的分類式 VQA。
+
+整個方法的關鍵不是新網路，而是一條資料引擎。作者從 PubMed Central 萃取的大規模圖說資料集 PMC-15M（1500 萬組生物醫學影像—文字配對）取樣，再用 language-only GPT-4 只根據文字（圖說 caption 以及原文中提及該圖的句子 citances）自我生成（self-instruct）指令跟隨資料。GPT-4 全程看不到影像，只被要求用「彷彿看得到圖」的語氣產生多輪問答，因此整條流程零人工標註。
+
+第一階段用的概念對齊資料，是把 600K 從 PMC-15M 取樣的影像—文字對，用最樸素的擴充法轉成指令：指令只要求「描述這張圖」，而目標輸出就是原始的 caption。依 caption 長度在「簡短描述」與「詳細描述」兩組問句之間切換，以 30 詞為分界（PMC-15M 中約 25% 的 caption 少於 30 詞）。這一階段只涵蓋單一任務（影像描述），目的在鋪滿生物醫學概念的覆蓋面。
+
+第二階段用的指令微調資料，則先篩掉多子圖、只保留單一子圖的影像，再從 CXR（胸部 X 光）、CT、MRI、histopathology、gross pathology 這五種最常見模態取樣 60K 組，用 GPT-4 生成多輪問答，並把 PubMed 原文中提及該圖的句子（inline mentions, IM）當作額外脈絡。作者刻意做了三個版本——10K、60K、60K-IM——以消融資料生成策略對下游模型的影響。
+
+每一筆對齊樣本被組織成單輪的指令跟隨格式，其中 $\Xmat_{\texttt{q}}$ 是取樣到的描述指令、$\Xmat_{\texttt{v}}$ 是影像、$\Xmat_{\texttt{c}}$ 是作為目標輸出的 caption：
+
+```
+Human : X_q  X_v  <STOP>\n
+Assistant : X_c  <STOP>\n
+```
+
+模型結構直接沿用 LLaVA：一個視覺編碼器、一個線性投影層、一個語言模型。訓練採兩階段課程學習（curriculum learning）。Stage 1（生物醫學概念特徵對齊）同時凍結視覺編碼器與語言模型，只更新投影矩陣，把大量新的生物醫學視覺概念對齊到語言模型既有的詞嵌入；Stage 2（端到端指令微調）只凍結視覺編碼器，同時更新投影層與語言模型的權重，讓模型學會開放式對話語義。作者把這個過程類比成一個外行人逐步被訓練成專業助手。
+
+![圖 3：LLaVA-Med 兩階段課程學習訓練流程示意](imgs/training_pipeline.png)
+
+這套配方主打「可負擔」：Stage 1 與 Stage 2 分別約 7 與 8 小時、合計不到 15 小時，跑在 8 張 40G A100 GPU 上，這也是標題「in One Day」的由來。作者提供了各階段、各 epoch 的實際耗時，讓使用者能自行做成本—品質取捨：
+
+| 階段 / epoch | Stage 1 (1 ep) | Stage 1 (3 ep) | Stage 2 10K (1 ep) | Stage 2 10K (3 ep) | Stage 2 60K (1 ep) | Stage 2 60K (3 ep) |
+|-|-|-|-|-|-|-|
+| 時間（小時） | 6.8 | 19.4 | 0.6 | 1.8 | 2.6 | 8.0 |
+
+評估分成兩條軸線。第一條是開放式視覺對話：作者構建 193 題全新問題（143 題 conversation 加 50 題 detailed description），用 language-only GPT-4 當裁判，對候選模型與 GPT-4 參考答案在有用性、相關性、正確性、細節程度上評分，再以 GPT-4 的參考分數正規化算出相對分數（relative score）。下表是各設定在這 193 題上的整體相對分數：
+
+| 模型設定 | Conversation | Description | Overall |
+|-|-|-|-|
+| LLaVA | 39.4 | 26.2 | 36.1 |
+| LLaVA-Med Stage 1 | 22.6 | 25.2 | 23.3 |
+| LLaVA-Med 10K | 42.4 | 32.5 | 39.9 |
+| LLaVA-Med 60K | 53.7 | 36.9 | 49.4 |
+| LLaVA-Med 60K-IM | 55.1 | 36.4 | 50.2 |
+
+走一遍實際數字更能看清課程學習的作用：通用 LLaVA 的整體相對分數是 36.1；只做 Stage 1 反而掉到 23.3，因為單一的影像描述指令讓模型喪失跟隨多樣指令的能力；補上 Stage 2 指令資料後，10K→60K→60K-IM 分別回升到 39.9、49.4、50.2，最佳的 60K-IM 版本達到 GPT-4 參考上限的 50.2%。這條曲線同時說明兩件事：Stage 1 單獨不足以當聊天機器人，而指令資料量與 inline mentions 都對品質有正貢獻。
+
+第二條軸線是三個既有的生物醫學 VQA 基準：VQA-RAD、SLAKE、PathVQA。封閉式問題報 accuracy、開放式問題報 recall（因為 LLaVA-Med 以自由文字生成作答，而非從候選集挑選）。下表節錄下游微調後與過往 supervised SoTA 的比較（closed-set accuracy）：
+
+| 方法 | VQA-RAD Closed | SLAKE Closed | PathVQA Closed |
+|-|-|-|-|
+| LLaVA | 65.07 | 63.22 | 63.20 |
+| LLaVA-Med (From LLaVA) | 84.19 | 85.34 | 91.21 |
+| LLaVA-Med (BioMed CLIP) | 83.09 | 86.78 | 91.09 |
+| M2I2 | 83.50 | 91.10 | 88.00 |
+
+經下游微調後，LLaVA-Med 在 VQA-RAD 與 PathVQA 的封閉式問題上刷新了 supervised SoTA（VQA-RAD closed 84.19、PathVQA closed 91.21），驗證了只要指令夠明確（例如是非題），模型就能可靠地依指令完成生物醫學任務。
+
+但在開放式問題上，LLaVA-Med 只在 SLAKE 上取得 SoTA，在其餘資料集上的表現受限、甚至落後既有方法；作者把原因歸給開放式生物醫學問題在不限定候選答案時本就語意模糊。這個誠實的自陳，正好標示出這條路徑的邊界。
+
+## 🧪 Critical Assessment
+
+### 醫學影像上的幻覺是安全風險，不只是品質瑕疵
+問題本身是真的：通用 LMM 在醫學影像上會像門外漢般幻覺，這在臨床脈絡下不只是品質瑕疵，而是安全風險。作者在結論也坦承 LLaVA-Med 仍受幻覺與淺層推理（weak in-depth reasoning）所限。把「領域適配」而非「更大模型」當成核心命題，對高價值但資料稀缺的垂直領域是合理且務實的切入點。
+
+### GPT-4 既是出題者也是閱卷者：循環評估的風險
+消融相當紮實：Table 3(b) 系統性地掃過 Stage 1/2 與下游微調的 epoch 數、7B vs 13B 語言模型、CLIP vs BioMedCLIP 視覺編碼器，並附上 running time 供成本—品質取捨。真正的隱憂在指標：聊天品質的主指標是 GPT-4 自評的 relative score，而訓練資料也由 GPT-4 生成——同一個模型家族既當出題者又當閱卷者，存在循環評估（circular evaluation）的偏誤風險，數字漂亮未必等於獨立的臨床效度。
+
+### 新意在「圖說→指令」的資料配方與兩階段課程，而非架構
+就元件而言，LLaVA-Med 幾乎全用既有積木：LLaVA 架構、GPT-4 self-instruct、PMC-15M 資料、可選的 Vicuna 或 BioMedCLIP 初始化。真正的新意集中在「圖說→指令」的資料生成配方與兩階段課程，較接近把一套成熟配方成功遷移到高價值垂直領域，而非架構層級的創新。持平地說，其資料集與流程的開源、以及低到「一天內」的訓練成本本身，就是有實用價值的貢獻，不宜只以「重組」一筆帶過。
+
+### 封閉式刷新 SoTA、開放式仍落後：能力邊界與 193 題基準的自我耦合
+「解決了嗎」必須分開看。封閉式 VQA 刷新 SoTA，本質是把是非/選擇題用生成式模型答對；而更貼近真實臨床提問的開放式問題，LLaVA-Med 反而多半落後既有方法，顯示開放式生物醫學理解遠未被解決。此外，193 題的視覺對話基準是作者用與訓練資料同一條 self-instruct 管線生成的，基準的定義與模型的強項高度耦合，且 GPT-4 參考答案吃到 golden caption 與 inline mentions、並非對影像的真實理解，使聊天分數更像內部一致性而非臨床效度。評估也未涉及真實部署、標註者一致性或安全稽核。因此本文更適合被理解為一個可負擔的領域適配「配方與資料資產」，而非臨床可用的成品系統。
+
+## 🔗 Related notes
+
+- [Stable Diffusion](../stable-diffusion/)

--- a/domains/vision_language/README.md
+++ b/domains/vision_language/README.md
@@ -9,9 +9,9 @@
 | Title | Venue | Year | Code | Review |
 |-|-|-|-|-|
 | [Stable Diffusion / Latent Diffusion Models](https://ommer-lab.com/research/latent-diffusion-models/) | CVPR | '22 | [✓](https://github.com/CompVis/latent-diffusion) | [✓](./stable-diffusion/) |
-| [LLaVA-Med: Training a Large Language-and-Vision Assistant for Biomedicine in One Day](https://arxiv.org/abs/2306.00890) | NeurIPS | '23 | [✓](https://github.com/microsoft/LLaVA-Med) | [✓](./LLaVA-Med/) |
-| [Alpha-CLIP: A CLIP Model Focusing on Wherever You Want](https://arxiv.org/abs/2312.03818) | CVPR | '24 | [✓](https://aleafy.github.io/alpha-clip) | [✓](./Alpha-CLIP/) |
-| [VideoLLM-online: Online Video Large Language Model for Streaming Video](https://arxiv.org/abs/2406.11816) | CVPR | '24 | [✓](https://github.com/showlab/videollm-online) | [✓](./VideoLLM-online/) |
-| [Video-MME: The First-Ever Comprehensive Evaluation Benchmark of Multi-modal LLMs in Video Analysis](https://arxiv.org/abs/2405.21075) | CVPR | '25 | [✓](https://video-mme.github.io) | [✓](./Video-MME/) |
-| [Why Far Looks Up: Probing Spatial Representation in Vision-Language Models](https://arxiv.org/abs/2605.30161) | ECCV | '26 | [✓](https://github.com/cheolhong0916/contrastive-probing) | [✓](./WhyFarLooksUp/) |
+| [LLaVA-Med: Training a Large Language-and-Vision Assistant for Biomedicine in One Day](https://arxiv.org/abs/2306.00890) | NeurIPS | '23 | [✓](https://github.com/microsoft/LLaVA-Med) | [EN](./LLaVA-Med/) · [中文](./LLaVA-Med/README.zh-TW.md) |
+| [Alpha-CLIP: A CLIP Model Focusing on Wherever You Want](https://arxiv.org/abs/2312.03818) | CVPR | '24 | [✓](https://aleafy.github.io/alpha-clip) | [EN](./Alpha-CLIP/) · [中文](./Alpha-CLIP/README.zh-TW.md) |
+| [VideoLLM-online: Online Video Large Language Model for Streaming Video](https://arxiv.org/abs/2406.11816) | CVPR | '24 | [✓](https://github.com/showlab/videollm-online) | [EN](./VideoLLM-online/) · [中文](./VideoLLM-online/README.zh-TW.md) |
+| [Video-MME: The First-Ever Comprehensive Evaluation Benchmark of Multi-modal LLMs in Video Analysis](https://arxiv.org/abs/2405.21075) | CVPR | '25 | [✓](https://video-mme.github.io) | [EN](./Video-MME/) · [中文](./Video-MME/README.zh-TW.md) |
+| [Why Far Looks Up: Probing Spatial Representation in Vision-Language Models](https://arxiv.org/abs/2605.30161) | ECCV | '26 | [✓](https://github.com/cheolhong0916/contrastive-probing) | [EN](./WhyFarLooksUp/) · [中文](./WhyFarLooksUp/README.zh-TW.md) |
 

--- a/domains/vision_language/Video-MME/README.md
+++ b/domains/vision_language/Video-MME/README.md
@@ -1,4 +1,5 @@
 # Video-MME — Research Note
+> **English** | [繁體中文](./README.zh-TW.md)
 
 ## 📇 Academic Context
 
@@ -7,31 +8,31 @@
 | Title | Video-MME: The First-Ever Comprehensive Evaluation Benchmark of Multi-modal LLMs in Video Analysis |
 | Venue | CVPR 2025 |
 | Year | 2025 |
-| Authors | Chaoyou Fu, Yuhan Dai, Yongdong Luo, Lei Li, Shuhuai Ren, ..., Ran He, Xing Sun（共 21 位作者，NJU / XMU / HKU / PKU / CUHK / ECNU / CASIA 等） |
+| Authors | Chaoyou Fu, Yuhan Dai, Yongdong Luo, Lei Li, Shuhuai Ren, ..., Ran He, Xing Sun (21 authors total, from NJU / XMU / HKU / PKU / CUHK / ECNU / CASIA, etc.) |
 | Official Code | https://video-mme.github.io |
 | Venue Kind | paper |
 
 ## First Principles
 
-### 這篇論文到底想解決什麼
+### What exactly does this paper try to solve
 
-多模態大語言模型（MLLM）過去的評測幾乎都集中在**靜態影像**理解，缺少一個能全面、細緻衡量模型「看影片」能力的高品質基準。Video-MME 就是為了填補這個缺口而生：它手工蒐集 900 支 YouTube 影片、標註 2,700 題四選一選擇題（每支影片 3 題），橫跨 6 大領域（Knowledge、Film & Television、Sports Competition、Artistic Performance、Life Record、Multilingual）與 30 個細分類別，影片長度從 11 秒橫跨到 1 小時。它同時把 subtitles 與 audios 一起納入評測，讓評測不只看畫面。（本筆記基於 arXiv:2405.21075 版本，即 CVPR 2025 camera-ready 原始碼，正式會議版可能略有差異。）
+Past evaluations of multimodal large language models (MLLMs) almost all concentrated on **static image** understanding, lacking a high-quality benchmark that comprehensively and finely measures a model's ability to "watch video." Video-MME was born to fill this gap: it manually collects 900 YouTube videos and annotates 2,700 four-way multiple-choice questions (3 per video), spanning 6 major domains (Knowledge, Film & Television, Sports Competition, Artistic Performance, Life Record, Multilingual) and 30 fine-grained categories, with video lengths ranging from 11 seconds to 1 hour. It also incorporates subtitles and audios into the evaluation, so that the evaluation is not only about the visuals. (This note is based on the arXiv:2405.21075 version, i.e. the CVPR 2025 camera-ready source; the official conference version may differ slightly.)
 
-![Video-MME 的統計分析：左為 6 領域 30 子類的分佈，右為影片時長與題型分佈](imgs/Video-MME.png)
+![Video-MME's statistical analysis: left is the distribution of 6 domains and 30 subcategories, right is the distribution of video duration and question types](imgs/Video-MME.png)
 
-作者刻意用三步驟壓出資料品質：先依 YouTube 熱門趨勢建立領域階層並蒐集短（< 2 分鐘）、中（4–15 分鐘）、長（30–60 分鐘）三檔影片，取得 900 videos with 744 subtitles and 900 audio files；再由具備 vision-language 研究經驗的標註者逐支看完影片後出題；最後做人工複審，並且把「只給文字題幹」的題目餵給 Gemini 1.5 Pro，凡是純文字就能答對的題目一律剔除。統計顯示 Gemini 1.5 Pro achieves less than 15% accuracy in the text-only setup，用來反證題目確實需要看影片才能作答。
+The authors deliberately use a three-step procedure to squeeze out data quality: first they build a domain hierarchy based on trending YouTube topics and collect short (< 2 minutes), medium (4–15 minutes), and long (30–60 minutes) videos, obtaining 900 videos with 744 subtitles and 900 audio files; then annotators with vision-language research experience watch each video in full before writing questions; finally there is a manual review, and questions that give "only the text stem" are fed to Gemini 1.5 Pro, and any question answerable from text alone is removed. Statistics show that Gemini 1.5 Pro achieves less than 15% accuracy in the text-only setup, which is used to counter-prove that the questions indeed require watching the video to be answered.
 
-### 用 certificate length 量化「這題到底有多難」
+### Using certificate length to quantify "how hard is this question"
 
-如何客觀衡量一題需要「看多久影片」才能答對？Video-MME 沿用 EgoSchema 的 certificate length：一個 QA 對的 certificate 是「足以讓人類驗證者確認標註答案正確」的最小必要子片段集合，certificate length 則是這些子片段時長的總和。以下用我們自訂的記號把這個定義寫成式子（notation 為本筆記所加）：
+How to objectively measure how long a question requires "watching the video" to answer? Video-MME follows EgoSchema's certificate length: the certificate of a QA pair is "the minimal necessary set of sub-clips sufficient for a human verifier to confirm the annotated answer is correct," and the certificate length is the total duration of these sub-clips. Below we write this definition as a formula using our own notation (the notation is added by this note):
 
 $$\mathrm{CL}(q) = \sum_{c \in \mathcal{C}(q)} \lvert c \rvert$$
 
-其中 $\mathcal{C}(q)$ 是題目 $q$ 的最小充分子片段集合，$\lvert c \rvert$ 是子片段 $c$ 的時長。作者從每個類別隨機抽 3 支影片估計分佈，得到短、中、長影片的 median certificate length 分別為 26s, 164.7s, and 890.7s——長影片子集需要消化的內容遠超 EgoSchema（其影片上限僅 180 秒），這也是作者宣稱 Video-MME 是「最具挑戰性」影片 QA 資料集的主要依據。
+where $\mathcal{C}(q)$ is the minimal sufficient set of sub-clips for question $q$, and $\lvert c \rvert$ is the duration of sub-clip $c$. The authors randomly sample 3 videos per category to estimate the distribution, obtaining median certificate lengths for short, medium, and long videos of 26s, 164.7s, and 890.7s respectively — the long-video subset requires digesting far more content than EgoSchema (whose videos cap at just 180 seconds), which is the main basis for the authors' claim that Video-MME is the "most challenging" video QA dataset.
 
-### 主結果一眼看懂
+### The main results at a glance
 
-下表節錄 Table「Performance of MLLMs on Video-MME」中具代表性的幾列（overall 為不分時長的整體準確率，%）：
+The table below excerpts a few representative rows from the "Performance of MLLMs on Video-MME" table (overall is the overall accuracy across all durations, %):
 
 | Model | LLM Params | Short w/o subs | Long w/o subs | Overall w/o subs | Overall w/ subs |
 |-|-|-|-|-|-|
@@ -42,32 +43,32 @@ $$\mathrm{CL}(q) = \sum_{c \in \mathcal{C}(q)} \lvert c \rvert$$
 | VITA-1.5 | 7B | 67.0 | 47.1 | 56.1 | 58.7 |
 | InternVL-Chat-V1.5 | 20B | 60.2 | 45.6 | 50.7 | 52.4 |
 
-只用影格輸入時，Gemini 1.5 Pro attains an accuracy of 75%，領先 GPT-4o 的 71.9% 與 GPT-4V；最強開源模型 VILA-1.5（34B）only reaches 59.0% overall，與商用模型仍有明顯落差。值得注意的是純影像模型 InternVL-Chat-V1.5 靠多影格輸入也能到 50.7%，與影片專用模型 LLaVA-NeXT-Video 相當，作者以此論證 image understanding is the foundation of video understanding，也證明基準對影像／影片模型都適用。
+Using frame input alone, Gemini 1.5 Pro attains an accuracy of 75%, ahead of GPT-4o's 71.9% and GPT-4V; the strongest open-source model VILA-1.5 (34B) only reaches 59.0% overall, still with a clear gap from commercial models. Notably, the pure-image model InternVL-Chat-V1.5 also reaches 50.7% by multi-frame input, comparable to the video-specialized LLaVA-NeXT-Video, which the authors use to argue that image understanding is the foundation of video understanding, and to show that the benchmark is applicable to both image and video models.
 
-### 一個具體的模態消融例子
+### A concrete modality-ablation example
 
-![四個代表模型在各題型上的雷達圖，counting 是共同瓶頸](imgs/radar_performance.png)
+![Radar charts of four representative models across question types, with counting as the common bottleneck](imgs/radar_performance.png)
 
-把焦點放在 Gemini 1.5 Pro 的分類別消融（Table「Performance of Gemini 1.5 Pro across six major categories」）能看清多模態的價值。以 Multilingual 這一類的長影片為例：只給 frames 時準確率是 70.8%，加上 subtitles 後躍升到 87.5%（+16.7），改加 audio 則到 83.3%（+12.5）。放大到整個長影片子集，加字幕讓 overall 從 67.4% 提升到 77.4%（+10.1），而在短影片上加字幕只帶來 +2.8，說明字幕對長影片的邊際效益遠大於短影片。另一條軸線是時長：Gemini 1.5 Pro 從短到長影片準確率 declines by −14.3% from short to long videos，暴露出模型在長距時序關係上的弱點；作者把主因歸為長影片中推理題比例升高、固定影格數導致取樣過稀、以及長脈絡本身難解。
+Focusing on Gemini 1.5 Pro's per-category ablation (the "Performance of Gemini 1.5 Pro across six major categories" table) makes the value of multimodality clear. Take the long videos in the Multilingual category as an example: with only frames the accuracy is 70.8%, and after adding subtitles it jumps to 87.5% (+16.7), while adding audio instead reaches 83.3% (+12.5). Zooming out to the entire long-video subset, adding subtitles raises overall from 67.4% to 77.4% (+10.1), whereas on short videos adding subtitles only brings +2.8, showing that the marginal benefit of subtitles is far greater for long videos than short ones. Another axis is duration: Gemini 1.5 Pro's accuracy declines by −14.3% from short to long videos, exposing the model's weakness in long-range temporal relationships; the authors attribute the main causes to the rising proportion of reasoning questions in long videos, the fixed number of frames leading to over-sparse sampling, and the inherent difficulty of long contexts.
 
 ## 🧪 Critical Assessment
 
-### 問題是真的，但「第一個」的框定值得斟酌
+### The problem is real, but the "first-ever" framing is debatable
 
-影片理解評測不足是真問題：把 11 秒到 1 小時、含 subtitles 與 audios 的開放領域影片放進同一個手工標註基準，確實補上了既有 benchmark 的空缺。不過 the first-ever comprehensive 這個定位帶有行銷成分——同期已有 MVBench、TempCompass、EgoSchema 等多個影片 MLLM 基準，Video-MME 的差異化主要在「長影片 + 多模態 + 人工標註」的組合，而非單一維度的原創；把它讀成「一次把多個既有維度湊齊的工程整合」比「全新問題」更貼近事實。
+The insufficiency of video-understanding evaluation is a real problem: putting open-domain videos from 11 seconds to 1 hour, with subtitles and audios, into the same manually annotated benchmark indeed fills a gap in existing benchmarks. However, the positioning of "the first-ever comprehensive" carries a marketing element — contemporaneous benchmarks such as MVBench, TempCompass, and EgoSchema already existed for video MLLMs, and Video-MME's differentiation lies mainly in the combination of "long video + multimodal + manual annotation" rather than originality on any single dimension; reading it as "an engineering integration that assembles several existing dimensions at once" is closer to the fact than "a brand-new problem."
 
-### 度量與基線設計的幾個縫隙
+### Several gaps in metric and baseline design
 
-規模其實不大：2,700 題、每支影片僅 3 題，換算下來每個 30 子類別平均只有約 90 題，長影片子集更只有 300 題，統計上一個模型幾個百分點的差距很可能落在雜訊裡，但論文並未報告任何信賴區間或顯著性檢定。certificate length 只從每類抽 3 支影片估計（全表約 90 支），樣本極小，卻被用來支撐「最具挑戰性」這種全域宣稱，說服力有限。此外，主要的模態增益結論高度依賴單一模型 Gemini 1.5 Pro——分類別的模態消融只在它身上做，audio 幾乎沒有開源模型能吃，因此「subtitles 比 audio 有效」這類結論的外推性存疑。
+The scale is actually not large: 2,700 questions, with only 3 per video, which works out to an average of only about 90 questions per 30-subcategory, and the long-video subset has only 300 questions, so statistically a difference of a few percentage points between models likely falls within noise, yet the paper does not report any confidence interval or significance test. Certificate length is estimated from only 3 videos per category (about 90 videos across the whole table), an extremely small sample, yet it is used to support a global claim like "most challenging," which is unconvincing. Moreover, the main modality-gain conclusions heavily depend on a single model, Gemini 1.5 Pro — the per-category modality ablation is done only on it, and almost no open-source model can consume audio, so the extrapolability of conclusions like "subtitles are more effective than audio" is questionable.
 
-### 「自家出題自家評」帶來的循環風險
+### The circular risk from "setting your own questions and grading them yourself"
 
-題目過濾用的是 Gemini 1.5 Pro（filter out QA pairs answerable from text alone），而 Gemini 1.5 Pro 又是榜上第一名的受測模型，這構成一種微妙的循環：用某模型篩掉它自己覺得能純文字作答的題，可能系統性保留了對該模型視覺管線友善的題型，讓它在最終榜單佔優。論文沒有交叉用多個過濾器來排除這個偏差。領域清單本身也有小瑕疵：正文列 6 領域時只寫出 5 個（漏了 Artistic Performance），顯示標註流程的描述並非完全嚴謹。
+The question filtering uses Gemini 1.5 Pro (filter out QA pairs answerable from text alone), while Gemini 1.5 Pro is also the top-ranked tested model on the leaderboard, which constitutes a subtle circularity: using a model to filter out the questions it itself thinks can be answered from text alone may systematically retain question types friendly to that model's visual pipeline, letting it dominate the final leaderboard. The paper does not cross-use multiple filters to rule out this bias. The domain list itself also has a minor flaw: when the main text lists the 6 domains it only writes out 5 (omitting Artistic Performance), showing that the description of the annotation process is not entirely rigorous.
 
-### 這個基準真的推動了問題被解決嗎
+### Does this benchmark actually push the problem toward being solved
 
-作為「診斷工具」，Video-MME 是成功的：它清楚量化了「時長越長、準確率越低」與「多模態能補資訊」兩個現象，對社群定義下一步很有幫助。但它衡量的是模型能力，本身不提供任何解法；而且因為影片全部來自 YouTube 公開內容，較新的商用模型很可能在預訓練階段見過相關素材，造成潛在的資料污染，這會讓排行榜的絕對數字隨時間虛高。作為快照式排行榜它有時效性，作為「長影片理解已被解決」的證據則遠遠不夠。
+As a "diagnostic tool," Video-MME is successful: it clearly quantifies the two phenomena of "the longer the duration, the lower the accuracy" and "multimodality can supplement information," which helps the community define the next step. But it measures model capability and itself provides no solution; and because the videos all come from public YouTube content, newer commercial models may well have seen related material during pretraining, causing potential data contamination, which would inflate the leaderboard's absolute numbers over time. As a snapshot leaderboard it has a shelf life, but as evidence that "long-video understanding is solved" it falls far short.
 
 ## 🔗 Related notes
 
-<!-- 目前 vision_language 下沒有可安全解析的相關筆記，保留標題、暫留空。 -->
+<!-- There are currently no safely parseable related notes under vision_language; the heading is kept and left empty for now. -->

--- a/domains/vision_language/Video-MME/README.zh-TW.md
+++ b/domains/vision_language/Video-MME/README.zh-TW.md
@@ -1,0 +1,74 @@
+# Video-MME — Research Note
+> [English](./README.md) | **繁體中文**
+
+## 📇 Academic Context
+
+| Field | Value |
+|-|-|
+| Title | Video-MME: The First-Ever Comprehensive Evaluation Benchmark of Multi-modal LLMs in Video Analysis |
+| Venue | CVPR 2025 |
+| Year | 2025 |
+| Authors | Chaoyou Fu, Yuhan Dai, Yongdong Luo, Lei Li, Shuhuai Ren, ..., Ran He, Xing Sun（共 21 位作者，NJU / XMU / HKU / PKU / CUHK / ECNU / CASIA 等） |
+| Official Code | https://video-mme.github.io |
+| Venue Kind | paper |
+
+## First Principles
+
+### 這篇論文到底想解決什麼
+
+多模態大語言模型（MLLM）過去的評測幾乎都集中在**靜態影像**理解，缺少一個能全面、細緻衡量模型「看影片」能力的高品質基準。Video-MME 就是為了填補這個缺口而生：它手工蒐集 900 支 YouTube 影片、標註 2,700 題四選一選擇題（每支影片 3 題），橫跨 6 大領域（Knowledge、Film & Television、Sports Competition、Artistic Performance、Life Record、Multilingual）與 30 個細分類別，影片長度從 11 秒橫跨到 1 小時。它同時把 subtitles 與 audios 一起納入評測，讓評測不只看畫面。（本筆記基於 arXiv:2405.21075 版本，即 CVPR 2025 camera-ready 原始碼，正式會議版可能略有差異。）
+
+![Video-MME 的統計分析：左為 6 領域 30 子類的分佈，右為影片時長與題型分佈](imgs/Video-MME.png)
+
+作者刻意用三步驟壓出資料品質：先依 YouTube 熱門趨勢建立領域階層並蒐集短（< 2 分鐘）、中（4–15 分鐘）、長（30–60 分鐘）三檔影片，取得 900 videos with 744 subtitles and 900 audio files；再由具備 vision-language 研究經驗的標註者逐支看完影片後出題；最後做人工複審，並且把「只給文字題幹」的題目餵給 Gemini 1.5 Pro，凡是純文字就能答對的題目一律剔除。統計顯示 Gemini 1.5 Pro achieves less than 15% accuracy in the text-only setup，用來反證題目確實需要看影片才能作答。
+
+### 用 certificate length 量化「這題到底有多難」
+
+如何客觀衡量一題需要「看多久影片」才能答對？Video-MME 沿用 EgoSchema 的 certificate length：一個 QA 對的 certificate 是「足以讓人類驗證者確認標註答案正確」的最小必要子片段集合，certificate length 則是這些子片段時長的總和。以下用我們自訂的記號把這個定義寫成式子（notation 為本筆記所加）：
+
+$$\mathrm{CL}(q) = \sum_{c \in \mathcal{C}(q)} \lvert c \rvert$$
+
+其中 $\mathcal{C}(q)$ 是題目 $q$ 的最小充分子片段集合，$\lvert c \rvert$ 是子片段 $c$ 的時長。作者從每個類別隨機抽 3 支影片估計分佈，得到短、中、長影片的 median certificate length 分別為 26s, 164.7s, and 890.7s——長影片子集需要消化的內容遠超 EgoSchema（其影片上限僅 180 秒），這也是作者宣稱 Video-MME 是「最具挑戰性」影片 QA 資料集的主要依據。
+
+### 主結果一眼看懂
+
+下表節錄 Table「Performance of MLLMs on Video-MME」中具代表性的幾列（overall 為不分時長的整體準確率，%）：
+
+| Model | LLM Params | Short w/o subs | Long w/o subs | Overall w/o subs | Overall w/ subs |
+|-|-|-|-|-|-|
+| Gemini 1.5 Pro | - | 81.7 | 67.4 | 75.0 | 81.3 |
+| GPT-4o | - | 80.0 | 65.3 | 71.9 | 77.2 |
+| GPT-4V | - | 70.5 | 53.5 | 59.9 | 63.3 |
+| VILA-1.5 | 34B | 68.1 | 50.8 | 59.0 | 59.4 |
+| VITA-1.5 | 7B | 67.0 | 47.1 | 56.1 | 58.7 |
+| InternVL-Chat-V1.5 | 20B | 60.2 | 45.6 | 50.7 | 52.4 |
+
+只用影格輸入時，Gemini 1.5 Pro attains an accuracy of 75%，領先 GPT-4o 的 71.9% 與 GPT-4V；最強開源模型 VILA-1.5（34B）only reaches 59.0% overall，與商用模型仍有明顯落差。值得注意的是純影像模型 InternVL-Chat-V1.5 靠多影格輸入也能到 50.7%，與影片專用模型 LLaVA-NeXT-Video 相當，作者以此論證 image understanding is the foundation of video understanding，也證明基準對影像／影片模型都適用。
+
+### 一個具體的模態消融例子
+
+![四個代表模型在各題型上的雷達圖，counting 是共同瓶頸](imgs/radar_performance.png)
+
+把焦點放在 Gemini 1.5 Pro 的分類別消融（Table「Performance of Gemini 1.5 Pro across six major categories」）能看清多模態的價值。以 Multilingual 這一類的長影片為例：只給 frames 時準確率是 70.8%，加上 subtitles 後躍升到 87.5%（+16.7），改加 audio 則到 83.3%（+12.5）。放大到整個長影片子集，加字幕讓 overall 從 67.4% 提升到 77.4%（+10.1），而在短影片上加字幕只帶來 +2.8，說明字幕對長影片的邊際效益遠大於短影片。另一條軸線是時長：Gemini 1.5 Pro 從短到長影片準確率 declines by −14.3% from short to long videos，暴露出模型在長距時序關係上的弱點；作者把主因歸為長影片中推理題比例升高、固定影格數導致取樣過稀、以及長脈絡本身難解。
+
+## 🧪 Critical Assessment
+
+### 問題是真的，但「第一個」的框定值得斟酌
+
+影片理解評測不足是真問題：把 11 秒到 1 小時、含 subtitles 與 audios 的開放領域影片放進同一個手工標註基準，確實補上了既有 benchmark 的空缺。不過 the first-ever comprehensive 這個定位帶有行銷成分——同期已有 MVBench、TempCompass、EgoSchema 等多個影片 MLLM 基準，Video-MME 的差異化主要在「長影片 + 多模態 + 人工標註」的組合，而非單一維度的原創；把它讀成「一次把多個既有維度湊齊的工程整合」比「全新問題」更貼近事實。
+
+### 度量與基線設計的幾個縫隙
+
+規模其實不大：2,700 題、每支影片僅 3 題，換算下來每個 30 子類別平均只有約 90 題，長影片子集更只有 300 題，統計上一個模型幾個百分點的差距很可能落在雜訊裡，但論文並未報告任何信賴區間或顯著性檢定。certificate length 只從每類抽 3 支影片估計（全表約 90 支），樣本極小，卻被用來支撐「最具挑戰性」這種全域宣稱，說服力有限。此外，主要的模態增益結論高度依賴單一模型 Gemini 1.5 Pro——分類別的模態消融只在它身上做，audio 幾乎沒有開源模型能吃，因此「subtitles 比 audio 有效」這類結論的外推性存疑。
+
+### 「自家出題自家評」帶來的循環風險
+
+題目過濾用的是 Gemini 1.5 Pro（filter out QA pairs answerable from text alone），而 Gemini 1.5 Pro 又是榜上第一名的受測模型，這構成一種微妙的循環：用某模型篩掉它自己覺得能純文字作答的題，可能系統性保留了對該模型視覺管線友善的題型，讓它在最終榜單佔優。論文沒有交叉用多個過濾器來排除這個偏差。領域清單本身也有小瑕疵：正文列 6 領域時只寫出 5 個（漏了 Artistic Performance），顯示標註流程的描述並非完全嚴謹。
+
+### 這個基準真的推動了問題被解決嗎
+
+作為「診斷工具」，Video-MME 是成功的：它清楚量化了「時長越長、準確率越低」與「多模態能補資訊」兩個現象，對社群定義下一步很有幫助。但它衡量的是模型能力，本身不提供任何解法；而且因為影片全部來自 YouTube 公開內容，較新的商用模型很可能在預訓練階段見過相關素材，造成潛在的資料污染，這會讓排行榜的絕對數字隨時間虛高。作為快照式排行榜它有時效性，作為「長影片理解已被解決」的證據則遠遠不夠。
+
+## 🔗 Related notes
+
+<!-- 目前 vision_language 下沒有可安全解析的相關筆記，保留標題、暫留空。 -->

--- a/domains/vision_language/VideoLLM-online/README.md
+++ b/domains/vision_language/VideoLLM-online/README.md
@@ -1,4 +1,5 @@
 # VideoLLM-online — Research Note
+> **English** | [繁體中文](./README.zh-TW.md)
 
 ## 📇 Academic Context
 
@@ -11,107 +12,132 @@
 | Official Code | https://github.com/showlab/videollm-online |
 | Venue Kind | paper |
 
-> 本文根據 arXiv 版 `2406.11816`（CVPR camera-ready 的 Llama-3 升級版）撰寫，數值與引文均以論文
-> LaTeX 原始碼為準；正式會議版若有差異以 CVPR 官方版為主。引用次數在撰寫當下因 Semantic Scholar
-> API 回傳 HTTP 429 而標記為 unavailable，並非 0。
+> This note is written from the arXiv version `2406.11816` (the Llama-3-upgraded version of the CVPR
+> camera-ready); numbers and quotations follow the paper's LaTeX source, and if the official
+> conference version differs, the official CVPR version prevails. The citation count is marked as
+> unavailable at the time of writing because the Semantic Scholar API returned HTTP 429, not 0.
 
 ## First Principles
 
-### 問題設定：從「離線影片問答」到「影片串流對話」
+### Problem setup: from "offline video QA" to "streaming video dialogue"
 
-多數影片大型多模態模型（VideoLLM）把影片當成一段「事先挑好的短片」來理解：使用者上傳一段 clip，
-模型讀完整段後才吐出一次回答。本文主張這種離線範式無法支撐「隨時待命、貼著時間軸」的 AI 助理
-（例如 AR 眼鏡邊煮菜邊提醒你翻面）。作者把新問題命名為 video streaming dialogue：模型持續接收
-不斷刷新的影格，需要在正確的時間點主動說話，其餘時間保持沉默。
+Most video large multimodal models (VideoLLMs) treat a video as a "pre-selected short clip" to understand:
+the user uploads a clip, and the model reads the whole segment before emitting a single answer. This paper
+argues that this offline paradigm cannot support an "always-on, timeline-hugging" AI assistant (e.g. AR
+glasses that remind you to flip while you cook). The authors name the new problem video streaming dialogue:
+the model continuously receives constantly refreshing frames, needs to speak proactively at the right moment,
+and stay silent the rest of the time.
 
-作者把難點拆成三個彼此拉扯的維度。第一是 temporally aligned（時間對齊）：像「該翻牛排時提醒我」
-這種查詢要求模型逐格掃描、不能只給影片級別的整體回答。第二是 long-context（長脈絡）：要回答摘要與
-規劃問題，就得保留大量歷史視覺與語言 token，很快會撐爆 LLM 的 context window，也拖慢因果解碼速度
-並吃掉 GPU 記憶體。第三是 real-time（即時）：回應必須跟得上影片流速，才能做到 always-on。
+The authors decompose the difficulty into three mutually competing dimensions. The first is temporally aligned:
+a query like "remind me when it's time to flip the steak" requires the model to scan frame by frame and cannot
+just give a video-level overall answer. The second is long-context: to answer summary and planning questions,
+the model must retain a large amount of historical visual and language tokens, which quickly overruns the LLM's
+context window, slows down causal decoding, and eats up GPU memory. The third is real-time: the response must
+keep up with the video's stream rate to achieve always-on.
 
-形式化來說，給定 $t_1$ 之前的上下文 `[Ctx]` 與 $t_1$ 到 $t_2$ 之間持續進來的影格 `[Frame]`，模型
-的目標有兩層：先判斷「當前時刻 $t_2$ 是否適合開口做語言模型」，若判定要說話，才在該時刻做標準的
-next-token 語言模型。這個「先決定要不要說、再決定說什麼」的二段式結構，是後續所有設計的出發點。
+Formally, given the context `[Ctx]` before $t_1$ and the frames `[Frame]` continuously arriving between $t_1$
+and $t_2$, the model has a two-level objective: first decide "whether the current moment $t_2$ is suitable for
+doing language modeling," and only if it decides to speak, do standard next-token language modeling at that
+moment. This two-stage structure of "first decide whether to speak, then decide what to say" is the starting
+point of all subsequent designs.
 
-### 為什麼 per-frame 對話行不通：Streaming EOS 預測
+### Why per-frame dialogue doesn't work: Streaming EOS prediction
 
-一個直覺解法是把互動頻率拉到每一格：把每個影格當 query，逐格做語言模型，並在不需回答的影格輸出一句
-很短的話（例如「現在還不是回答的時候」）。但這會逼模型在每一格都跑一次冗長、循環的 billion 級
-next-token 解碼，速度上不可能即時，還會反覆消耗 `[INST]`、`[/INST]` 等對話模板 token，讓長影片的
-context 迅速膨脹。作者也實測過 GPT-4V 的 per-frame prompting：它傾向每一格都輸出長篇內容，造成明顯
-延遲，並不適合即時串流。
+An intuitive solution is to raise the interaction frequency to every frame: treat each frame as a query, do
+language modeling frame by frame, and on frames that need no answer output a very short utterance (e.g. "it's
+not the time to answer yet"). But this forces the model to run a lengthy, recurrent billion-scale next-token
+decoding on every frame, which cannot possibly be real-time in speed, and also repeatedly consumes dialogue
+template tokens like `[INST]`, `[/INST]`, making the context of long videos balloon quickly. The authors also
+empirically test GPT-4V's per-frame prompting: it tends to output long content on every frame, causing obvious
+latency, and is not suitable for real-time streaming.
 
-本文的核心貢獻是一個新的訓練目標 streaming EOS prediction（串流結束符預測）。對於「該回答」的時刻
-$t_2$，照常做語言模型：
+The core contribution of this paper is a new training objective, streaming EOS prediction. For a moment $t_2$
+that "should answer," do language modeling as usual:
 
 $$\max P(\texttt{[Txt}^{t_2}_{i+1}\texttt{]} \mid \texttt{[Ctx}^{<t_2}\texttt{]},\ \texttt{[Frame}^{t_2}\texttt{]},\ \texttt{[Txt}^{t_2}_{\le i}\texttt{]})$$
 
-而對於 $t_1 \le t < t_2$ 這些「冗餘、不需產生答案」的影格，則直接教模型在該影格 token 上預測 EOS：
+while for the "redundant, no-answer-needed" frames with $t_1 \le t < t_2$, directly teach the model to predict
+EOS on that frame's token:
 
 $$\max P(\text{EOS} \mid \texttt{[Ctx}^{<t}\texttt{]},\ \texttt{[Frame}^{t}\texttt{]}),\quad \text{where } t_1 \le t < t_2$$
 
-關鍵巧思在於：這個 EOS 只作為監督訊號，**不會被 append 進輸入/輸出序列**，因此不會像真的插入大量
-EOS token 那樣推高 perplexity，也不佔用 context。它本質上不是 next-token prediction（EOS 不出現在
-序列裡），卻能與自回歸損失並存，一起訓練出「知道何時該閉嘴」的串流模型。作者也強調這裡的 EOS 不必
-是語言模型原生的 `</s>`，可以是任何在 system prompt 中約定的 token。
+The key ingenuity is that this EOS serves only as a supervision signal and **is not appended into the
+input/output sequence**, so it does not raise perplexity the way actually inserting a large number of EOS
+tokens would, nor does it occupy context. It is essentially not next-token prediction (EOS never appears in the
+sequence), yet it can coexist with the autoregressive loss and together train a streaming model that "knows when
+to shut up." The authors also emphasize that the EOS here need not be the language model's native `</s>`, and can
+be any token agreed upon in the system prompt.
 
-### 訓練損失：語言建模損失 + 串流損失
+### Training loss: language modeling loss + streaming loss
 
-把兩個目標合起來，訓練損失是逐 token cross-entropy 的加總（符號沿用論文 Eq. 5）：
+Combining the two objectives, the training loss is the sum of per-token cross-entropy (the notation follows the
+paper's Eq. 5):
 
 $$L = \frac{1}{N}\sum_{j=1}^{N}\left(-\log l_{j+1} P_j^{\texttt{[Txt}_{j+1}\texttt{]}} -\ w\log f_j P_j^{\texttt{[EOS]}}\right)$$
 
-其中 $l_j$ 是語言 token 指示子（第 $j$ 個 token 是語言回應才為 1），$f_j$ 是串流指示子：當第 $j$ 個
-token 是某一影格的**最後一個** token、且下一個位置不是語言 token（$l_{j+1}=0$）時才為 1，也就是把
-EOS 監督只施加在「即將沉默」的影格上。$w$ 是平衡係數，預設 $w=1$。當每格只用 1 個 token 時，語言
-損失與串流損失在序列上的作用範圍如下圖標示。
+where $l_j$ is the language-token indicator (1 only if the $j$-th token is a language response), and $f_j$ is the
+streaming indicator: it is 1 only when the $j$-th token is the **last** token of a certain frame and the next
+position is not a language token ($l_{j+1}=0$), i.e. applying the EOS supervision only on frames "about to fall
+silent." $w$ is a balancing coefficient, defaulting to $w=1$. When each frame uses only 1 token, the ranges over
+which the language loss and streaming loss act on the sequence are marked in the figure below.
 
-![LIVE 訓練方法：影格 token 與語言 token 依時間交錯，Streaming Loss 監督沉默影格輸出 EOS、LM Loss 監督該回答時刻的語言 token](imgs/fig4.png)
+![The LIVE training method: frame tokens and language tokens interleave over time, the Streaming Loss supervises silent frames to output EOS, and the LM Loss supervises the language tokens at the moment to answer](imgs/fig4.png)
 
-### 資料引擎：把離線標註轉成串流對話
+### Data engine: turning offline annotations into streaming dialogue
 
-上述訓練需要「影片流內的使用者查詢與助理回應」資料，但主流影片資料集大多只有離線的時間段標註。作者
-提出兩條資料生成路線。對 Ego4D narration 這種本身就以串流方式標註（標註者邊看 5 分鐘影片邊即時描述）
-的資料，直接沿用給人類標註者的指示當作訓練 prompt。對只有時間段標註的離線資料（如 COIN），則用 LLM
-合成對話：先準備一個涵蓋過去/現在/未來時態的問題模板庫，作者共準備了每類 50 題、合計 $N=150$ 條查詢；
-接著把時間軸標註整理成「time $t_a \sim t_b$: boiling the water」這樣的語言 prompt，把所有狀態轉變的
-關鍵時間點視為理想回應時刻，再讓 LLM 在每個關鍵時間點生成回應。訓練時隨機抽一條查詢、隨機插入到某個
-時間戳 $t_r$、丟掉 $t_r$ 之前的回應，每個樣本最多插入 3 條查詢。
+The above training needs "user queries and assistant responses within the video stream" data, but mainstream
+video datasets mostly only have offline temporal-segment annotations. The authors propose two data-generation
+routes. For data that is itself annotated in a streaming way, like Ego4D narration (annotators describe in real
+time while watching a 5-minute video), they directly reuse the instructions given to human annotators as the
+training prompt. For offline data with only temporal-segment annotations (e.g. COIN), they synthesize dialogue
+with an LLM: first prepare a question template bank covering past/present/future tenses — the authors prepare 50
+questions per category, $N=150$ queries in total; then organize the timeline annotations into language prompts
+like "time $t_a \sim t_b$: boiling the water," treat all key timestamps of state transitions as ideal response
+moments, and let the LLM generate a response at each key timestamp. During training, one query is randomly
+sampled, randomly inserted at some timestamp $t_r$, and responses before $t_r$ are dropped; each sample inserts
+at most 3 queries.
 
-![LIVE 資料生成方法：把問題模板隨機插入影片時間軸，並將帶時間戳的 ground-truth 標註「曝露」給 LLM 以生成分時回應](imgs/fig3.png)
+![The LIVE data generation method: randomly inserting question templates into the video timeline, and "exposing" the timestamped ground-truth annotations to the LLM to generate time-segmented responses](imgs/fig3.png)
 
-### 模型架構與推論管線
+### Model architecture and inference pipeline
 
-架構延續 LLaVA 的三件式：影像編碼器、MLP projector、語言模型。影像編碼器用在 DataComp-1B 上預訓練的
-CLIP ViT-L，以 2 FPS 抽取影格 embedding，形狀為 $(1+h_p\times w_p)\times c$（1 個 CLS token 加上平均
-池化後的空間 token）。論文正文實驗刻意設 $h_p=w_p=0$，也就是每格只用 1 個 CLS token，這是最省的設定，
-可在 4096 context window 內處理近半小時影片；釋出的 demo 模型則用 $1+3\times3=10$ 個 token/格以換取
-更細的對話細節。影格 token 經 MLP 投影後與語言 token 交錯輸入 Llama-2-7B-Chat 或 Llama-3-8B-Instruct，
-並在每個線性層加上 LoRA 做高效微調（rank 128、scaling 256）。
+The architecture follows LLaVA's three parts: an image encoder, an MLP projector, and a language model. The
+image encoder uses a CLIP ViT-L pretrained on DataComp-1B, extracting frame embeddings at 2 FPS, of shape
+$(1+h_p\times w_p)\times c$ (1 CLS token plus average-pooled spatial tokens). The main-text experiments
+deliberately set $h_p=w_p=0$, i.e. only 1 CLS token per frame, which is the most economical setting and can
+process nearly half an hour of video within a 4096 context window; the released demo model uses $1+3\times3=10$
+tokens/frame to trade for finer dialogue detail. Frame tokens are projected by the MLP and interleaved with
+language tokens as input to Llama-2-7B-Chat or Llama-3-8B-Instruct, with LoRA added on every linear layer for
+efficient fine-tuning (rank 128, scaling 256).
 
-推論端有三個工程設計。其一是 probability correction：因為 EOS 太常見會讓模型偏向沉默，作者引入門檻
-$\theta$，只有當 $P_j^{\texttt{[EOS]}} \ge \theta$ 才把 EOS 當下一個 token，實務上 $\theta$ 設在
-$0.5 \sim 0.8$ 明顯優於不設門檻。其二是 continuous key-value cache：影片逐格串流輸入，靠 KV cache
-免去每格重算，配合「傾向沉默」的訓練讓連續推論很有效率。其三是 encoding/decoding 平行化：CLIP ViT-L
-（307M）遠小於 7B/8B 的 LLM，兩者速度落差會導致跳格；作者用一個 FIFO queue 讓快的編碼器持續編碼、
-不必等慢的 LLM 解碼完，避免瓶頸。
+The inference side has three engineering designs. The first is probability correction: because EOS is so common
+it biases the model toward silence, the authors introduce a threshold $\theta$, only taking EOS as the next token
+when $P_j^{\texttt{[EOS]}} \ge \theta$; in practice $\theta$ set at $0.5 \sim 0.8$ is clearly better than no
+threshold. The second is a continuous key-value cache: the video streams in frame by frame, and the KV cache
+avoids recomputing every frame, which combined with the "tend to be silent" training makes continuous inference
+very efficient. The third is encoding/decoding parallelization: CLIP ViT-L (307M) is far smaller than the 7B/8B
+LLM, and the speed gap between them would cause frame skipping; the authors use a FIFO queue to let the fast
+encoder keep encoding without waiting for the slow LLM to finish decoding, avoiding the bottleneck.
 
-![LIVE 推論管線：影格串流輸入，維持 continuous KV cache，並把快編碼器與慢 LLM 平行化以避免跳格](imgs/fig5.png)
+![The LIVE inference pipeline: frames stream in, a continuous KV cache is maintained, and the fast encoder is parallelized with the slow LLM to avoid frame skipping](imgs/fig5.png)
 
-### 一個帶真實數字的走查
+### A walkthrough with real numbers
 
-以論文預設的 VideoLLM-online-7B-v1（CLIP + Llama-2-7B-Chat，每格 1 個 CLS token）在一段 5 分鐘 Ego4D
-narration 上運作為例：@2 FPS 抽樣約產生 600 影格，每格 1 token，因此整段串流僅約 600 個影格 token，
-遠低於 4096 的 context 上限。假設在 $t_r$ 插入查詢「Remind me when X appears」，在 X 尚未出現的每個影格
-上，模型被監督在該影格最後一個 token 預測 EOS（保持沉默）；當 X 於 $t_2$ 出現時，模型才被監督輸出
-「appeared」這串語言 token。正因為沉默影格不佔序列，串流方法的平均訓練 token 長度只有 1694，相較
-per-frame streaming 的 6737 少了約 4 倍，訓練時間也從 22h 降到 12h。推論時設 $\theta \in [0.5, 0.8]$
-做 EOS 門檻校正，5 分鐘串流可在單張 A100 上以 18.2 GB 記憶體、平均 13.5 FPS 運作。
+Take the paper's default VideoLLM-online-7B-v1 (CLIP + Llama-2-7B-Chat, 1 CLS token per frame) running on a
+5-minute Ego4D narration as an example: sampling @2 FPS produces about 600 frames, 1 token per frame, so the whole
+stream is only about 600 frame tokens, far below the 4096 context limit. Suppose the query "Remind me when X
+appears" is inserted at $t_r$; on every frame before X appears, the model is supervised to predict EOS on that
+frame's last token (stay silent); when X appears at $t_2$, the model is supervised to output the "appeared"
+language tokens. Precisely because silent frames do not occupy the sequence, the streaming method's average
+training token length is only 1694, about 4× less than per-frame streaming's 6737, and the training time also
+drops from 22h to 12h. At inference, setting $\theta \in [0.5, 0.8]$ for EOS threshold correction, a 5-minute
+stream can run on a single A100 at 18.2 GB memory and an average 13.5 FPS.
 
-下表是串流學習方法的消融（Ego4D Narration Stream 驗證集，7B-v1）。No Training 的 LM-PPL 高達 498.5、
-Fluency 幾乎為 0；interleaved 對話雖把 PPL 壓到 2.45，但 TimeDiff 仍有 6.47、幾乎不會沉默；per-frame
-streaming 把 TimeDiff 降到 2.52 卻犧牲了 PPL（3.34）。本文的 streaming 方法在三項指標上都最好，且訓練
-token 與成本與最省的 interleaved 相同。
+The table below is the ablation of streaming learning methods (Ego4D Narration Stream validation set, 7B-v1). No
+Training has an LM-PPL as high as 498.5 and near-zero Fluency; the interleaved dialogue does compress PPL to 2.45
+but still has a TimeDiff of 6.47 and almost never stays silent; per-frame streaming lowers TimeDiff to 2.52 but
+sacrifices PPL (3.34). This paper's streaming method is the best on all three metrics, with the same training
+tokens and cost as the most economical interleaved.
 
 | Method | Objective | LM-PPL↓ | TimeDiff↓ | Fluency↑ | #Train Token↓ | Cost |
 |-|-|-|-|-|-|-|
@@ -120,8 +146,9 @@ token 與成本與最省的 interleaved 相同。
 | Per-frame for Streaming | LM (w/ EOS turns) | 3.34 | 2.52 | 37.7% | 6737 | 22h |
 | Streaming Dialogue (Ours) | LM + Streaming EOS | 2.43 | 2.32 | 42.6% | 1694 | 12h |
 
-效率消融同樣支持串流設計：interleaved 因每格都輸出語言而吃 34.4 GB、只有 1.5 FPS；per-frame streaming
-改善到 24.9 GB / 7.5 FPS；本文 streaming 因不在冗餘影格花 token、KV cache 較小，達到 18.2 GB / 13.5 FPS。
+The efficiency ablation similarly supports the streaming design: interleaved consumes 34.4 GB and only 1.5 FPS
+because it outputs language on every frame; per-frame streaming improves to 24.9 GB / 7.5 FPS; this paper's
+streaming, because it spends no tokens on redundant frames and has a smaller KV cache, reaches 18.2 GB / 13.5 FPS.
 
 | Method | Mem↓ | FPS↑ |
 |-|-|-|
@@ -129,10 +156,11 @@ token 與成本與最省的 interleaved 相同。
 | Per-frame Streaming | 24.9G | 7.5 |
 | Streaming | 18.2G | 13.5 |
 
-在離線 benchmark 上，作者宣稱在 end-to-end 模型中取得 SOTA。COIN 六項 Top-1 Accuracy 中，7B-v1 的 step
-recognition 為 59.8、8B-v1+ 更達 63.1，皆高於先前最佳的 VideoTaskGraph（57.2）；Ego4D LTA 的
-ED@Z=20（越低越好）Action 欄，8B-v1+ 為 0.884，優於同為 end-to-end 的 VideoLLM（0.921），但仍略遜於
-使用 egocentric 預訓練特徵、且串接多重複雜方法的非 end-to-end AntGPT（0.877）。
+On offline benchmarks, the authors claim SOTA among end-to-end models. Among COIN's six Top-1 Accuracy metrics,
+7B-v1's step recognition is 59.8, and 8B-v1+ reaches 63.1, both higher than the previous best VideoTaskGraph
+(57.2); on Ego4D LTA's ED@Z=20 (lower is better) Action column, 8B-v1+ is 0.884, better than the equally
+end-to-end VideoLLM (0.921), but still slightly behind the non-end-to-end AntGPT (0.877), which uses egocentric
+pretraining features and cascades multiple complex methods.
 
 | Method | COIN Step↑ | COIN Task↑ | Ego4D LTA Action ED↓ |
 |-|-|-|-|
@@ -143,43 +171,58 @@ ED@Z=20（越低越好）Action 欄，8B-v1+ 為 0.884，優於同為 end-to-end
 
 ## 🧪 Critical Assessment
 
-### 問題是真需求，還是為方法量身打造的設定
+### Is the problem a real need, or a setting tailored to the method
 
-「always-on 影片助理」的動機是可信的：GPT-4o 當時的多模態互動仍需人聲觸發，逐格提醒/摘要/預測確實是
-未被滿足的能力。streaming EOS 這個「用不進序列的監督訊號教模型何時沉默」的想法也乾淨而有效，屬於實質
-創新而非改名包裝。但要留意的是，論文賴以立論的主要評測——Ego4D Narration Stream——高度貼合作者方法的
-強項：作者自己也承認 narration 文本「相對簡單，主要由主詞、動詞、受詞構成」，因此 LM-PPL 與 LG-Match
-才勉強適用。換句話說，這個串流基準是圍繞方法能發揮的簡單語言場景所定義的，對更複雜、free-form 的線上
-對話能力，論文明說現有指標「並不有效」並留待未來工作。這是一種評測邊界的自我圈定，需要讀者警覺。
+The motivation for an "always-on video assistant" is credible: GPT-4o's multimodal interaction at the time still
+needed a human voice to trigger, and frame-by-frame reminders/summaries/predictions are indeed an unmet
+capability. The idea of streaming EOS — "a supervision signal that never enters the sequence, teaching the model
+when to be silent" — is also clean and effective, a substantive innovation rather than a rebrand. But note that
+the main evaluation the paper relies on to make its case — Ego4D Narration Stream — is highly aligned with the
+method's strengths: the authors themselves admit narration text is "relatively simple, mainly consisting of
+subject, verb, object," which is why LM-PPL and LG-Match are barely applicable. In other words, this streaming
+benchmark is defined around the simple language scenario the method can excel at, and for more complex, free-form
+online dialogue ability, the paper explicitly says existing metrics are "not effective" and leaves it to future
+work. This is a self-drawn evaluation boundary that the reader should be alert to.
 
-### 基線、消融與指標是否足夠
+### Are the baselines, ablations, and metrics sufficient
 
-正面看，消融相當完整：學習方法（interleaved / per-frame / streaming）、串流損失函數（CE vs OHEM vs
-Focal）、損失權重 $\tau$、以及記憶體/速度都各有一張表，且 CE、$\tau=1.0$ 的預設選擇有數據支撐。但有幾
-處缺口值得質疑。其一，TimeDiff、Fluency、LG-Match 三項核心指標全是作者自定義，沒有外部資料集或既有
-文獻的可比基準，讀者難以判斷 2.32 秒的 TimeDiff 在絕對意義上算好還是普通。其二，主要串流實驗只在單一
-資料集（Ego4D narration）驗證，COIN+Ego4D 的 free-form 設定僅作定性展示，缺乏跨資料集的量化外推。其三，
-所有數字看不到多次隨機種子的變異或信賴區間，像 $\tau=0.5/1.0/2.0$ 之間 Fluency 只差 0.2 個百分點這種
-差距，是否統計顯著並不明朗。
+On the positive side, the ablation is quite complete: the learning method (interleaved / per-frame / streaming),
+the streaming loss function (CE vs OHEM vs Focal), the loss weight $\tau$, and memory/speed each have a table,
+and the default choice of CE and $\tau=1.0$ is data-supported. But there are several gaps worth questioning.
+First, the three core metrics TimeDiff, Fluency, and LG-Match are all defined by the authors, with no comparable
+baseline from an external dataset or existing literature, so the reader can hardly judge whether a TimeDiff of
+2.32 seconds is good or ordinary in absolute terms. Second, the main streaming experiment is only validated on a
+single dataset (Ego4D narration), and the free-form setting of COIN+Ego4D is only shown qualitatively, lacking
+cross-dataset quantitative extrapolation. Third, none of the numbers show variance or confidence intervals across
+multiple random seeds; for a gap like Fluency differing by only 0.2 percentage points among $\tau=0.5/1.0/2.0$,
+whether it is statistically significant is unclear.
 
-### 離線 SOTA 的宣稱要打折扣看
+### The offline SOTA claim should be read with a discount
 
-論文標題與敘事把「離線 benchmark SOTA」當作賣點，但表格裡的比較條件並不完全對等。作者的 SOTA 宣稱限定
-在「end-to-end 模型」這個子集：在 Ego4D LTA 上，真正最佳的 AntGPT（0.877）與 Palm 都被以灰字列在
-end-to-end 分隔線之下，理由是它們用了 egocentric 預訓練特徵與級聯方法。這個界定本身合理且有揭露，但把
-它讀成「無條件 SOTA」會失真——本文的 0.884 其實仍輸給既有非 end-to-end 方法。COIN 一側則加了「Not use
-HT100M」欄位來凸顯自身未用額外預訓練，這雖是公平性論述，也同時是縮小可比集合、讓自己更突出的框定方式。
+The paper's title and narrative make "offline benchmark SOTA" a selling point, but the comparison conditions in
+the tables are not entirely on par. The authors' SOTA claim is restricted to the subset of "end-to-end models":
+on Ego4D LTA, the truly best AntGPT (0.877) and Palm are listed in gray below the end-to-end dividing line, on
+the grounds that they use egocentric pretraining features and cascaded methods. This delineation itself is
+reasonable and disclosed, but reading it as "unconditional SOTA" would distort it — this paper's 0.884 actually
+still loses to existing non-end-to-end methods. On the COIN side, a "Not use HT100M" column is added to highlight
+that the authors used no extra pretraining, which, while a fairness argument, is also a way of shrinking the
+comparable set to make itself stand out more.
 
-### 是否真的解決了宣稱的問題，以及現實相關性
+### Does it really solve the claimed problem, and its real-world relevance
 
-就「能否在單卡上以 >10 FPS 跑 5 分鐘串流並適時回應」這個工程目標而言，論文的證據（13.5 FPS、18.2 GB）
-是有說服力的，方法在其定義的任務上確實可用。但「解決 always-on 影片助理」這個更大的敘事仍有距離：正文
-實驗刻意用每格 1 token 的最省設定，作者自陳這會犧牲空間細節，需要更多空間 token 才能做好 zero-shot 的
-下游空間理解，而這正被列為未來工作；demo 用的 10 token/格設定則沒有進入量化評測。此外，資料引擎依賴
-Llama-2/3 為 COIN 標註「幻想」出對話回應，這些合成回應的正確性與偏誤沒有被系統性評估，可能把 LLM 的
-既有偏差引入監督訊號。因此比較穩妥的結論是：本文在一個定義清晰但相對狹窄的串流敘述任務上給出了漂亮且
-高效的解法，但距離其願景中通用、free-form 的即時助理，仍是一個有前景的起點而非終點。
+For the engineering goal of "can it run a 5-minute stream at >10 FPS on a single GPU and respond in a timely
+manner," the paper's evidence (13.5 FPS, 18.2 GB) is convincing, and the method is indeed usable on its defined
+task. But the larger narrative of "solving the always-on video assistant" still has a distance: the main-text
+experiments deliberately use the most economical 1-token-per-frame setting, and the authors admit this sacrifices
+spatial detail and that more spatial tokens are needed to do zero-shot downstream spatial understanding well,
+which is precisely listed as future work; the demo's 10-token/frame setting does not enter the quantitative
+evaluation. Moreover, the data engine relies on Llama-2/3 to "hallucinate" dialogue responses for COIN
+annotations, and the correctness and bias of these synthetic responses are not systematically evaluated, possibly
+introducing the LLM's existing bias into the supervision signal. Therefore the more measured conclusion is: this
+paper gives a beautiful and efficient solution on a clearly defined but relatively narrow streaming-narration
+task, but relative to its vision of a general, free-form real-time assistant, it remains a promising starting
+point rather than an endpoint.
 
 ## 🔗 Related notes
 
-<!-- 目前 domains/vision_language 下無與串流影片對話直接相關且可解析的既有筆記，故保留標題留空。 -->
+<!-- There are currently no parseable existing notes under domains/vision_language directly related to streaming video dialogue, so the heading is kept empty. -->

--- a/domains/vision_language/VideoLLM-online/README.zh-TW.md
+++ b/domains/vision_language/VideoLLM-online/README.zh-TW.md
@@ -1,0 +1,186 @@
+# VideoLLM-online — Research Note
+> [English](./README.md) | **繁體中文**
+
+## 📇 Academic Context
+
+| Field | Value |
+|-|-|
+| Title | VideoLLM-online: Online Video Large Language Model for Streaming Video |
+| Venue | CVPR 2024 |
+| Year | 2024 |
+| Authors | Joya Chen, Zhaoyang Lv, Shiwei Wu, Kevin Qinghong Lin, Chenan Song, Difei Gao, Jia-Wei Liu, Ziteng Gao, Dongxing Mao, Mike Zheng Shou |
+| Official Code | https://github.com/showlab/videollm-online |
+| Venue Kind | paper |
+
+> 本文根據 arXiv 版 `2406.11816`（CVPR camera-ready 的 Llama-3 升級版）撰寫，數值與引文均以論文
+> LaTeX 原始碼為準；正式會議版若有差異以 CVPR 官方版為主。引用次數在撰寫當下因 Semantic Scholar
+> API 回傳 HTTP 429 而標記為 unavailable，並非 0。
+
+## First Principles
+
+### 問題設定：從「離線影片問答」到「影片串流對話」
+
+多數影片大型多模態模型（VideoLLM）把影片當成一段「事先挑好的短片」來理解：使用者上傳一段 clip，
+模型讀完整段後才吐出一次回答。本文主張這種離線範式無法支撐「隨時待命、貼著時間軸」的 AI 助理
+（例如 AR 眼鏡邊煮菜邊提醒你翻面）。作者把新問題命名為 video streaming dialogue：模型持續接收
+不斷刷新的影格，需要在正確的時間點主動說話，其餘時間保持沉默。
+
+作者把難點拆成三個彼此拉扯的維度。第一是 temporally aligned（時間對齊）：像「該翻牛排時提醒我」
+這種查詢要求模型逐格掃描、不能只給影片級別的整體回答。第二是 long-context（長脈絡）：要回答摘要與
+規劃問題，就得保留大量歷史視覺與語言 token，很快會撐爆 LLM 的 context window，也拖慢因果解碼速度
+並吃掉 GPU 記憶體。第三是 real-time（即時）：回應必須跟得上影片流速，才能做到 always-on。
+
+形式化來說，給定 $t_1$ 之前的上下文 `[Ctx]` 與 $t_1$ 到 $t_2$ 之間持續進來的影格 `[Frame]`，模型
+的目標有兩層：先判斷「當前時刻 $t_2$ 是否適合開口做語言模型」，若判定要說話，才在該時刻做標準的
+next-token 語言模型。這個「先決定要不要說、再決定說什麼」的二段式結構，是後續所有設計的出發點。
+
+### 為什麼 per-frame 對話行不通：Streaming EOS 預測
+
+一個直覺解法是把互動頻率拉到每一格：把每個影格當 query，逐格做語言模型，並在不需回答的影格輸出一句
+很短的話（例如「現在還不是回答的時候」）。但這會逼模型在每一格都跑一次冗長、循環的 billion 級
+next-token 解碼，速度上不可能即時，還會反覆消耗 `[INST]`、`[/INST]` 等對話模板 token，讓長影片的
+context 迅速膨脹。作者也實測過 GPT-4V 的 per-frame prompting：它傾向每一格都輸出長篇內容，造成明顯
+延遲，並不適合即時串流。
+
+本文的核心貢獻是一個新的訓練目標 streaming EOS prediction（串流結束符預測）。對於「該回答」的時刻
+$t_2$，照常做語言模型：
+
+$$\max P(\texttt{[Txt}^{t_2}_{i+1}\texttt{]} \mid \texttt{[Ctx}^{<t_2}\texttt{]},\ \texttt{[Frame}^{t_2}\texttt{]},\ \texttt{[Txt}^{t_2}_{\le i}\texttt{]})$$
+
+而對於 $t_1 \le t < t_2$ 這些「冗餘、不需產生答案」的影格，則直接教模型在該影格 token 上預測 EOS：
+
+$$\max P(\text{EOS} \mid \texttt{[Ctx}^{<t}\texttt{]},\ \texttt{[Frame}^{t}\texttt{]}),\quad \text{where } t_1 \le t < t_2$$
+
+關鍵巧思在於：這個 EOS 只作為監督訊號，**不會被 append 進輸入/輸出序列**，因此不會像真的插入大量
+EOS token 那樣推高 perplexity，也不佔用 context。它本質上不是 next-token prediction（EOS 不出現在
+序列裡），卻能與自回歸損失並存，一起訓練出「知道何時該閉嘴」的串流模型。作者也強調這裡的 EOS 不必
+是語言模型原生的 `</s>`，可以是任何在 system prompt 中約定的 token。
+
+### 訓練損失：語言建模損失 + 串流損失
+
+把兩個目標合起來，訓練損失是逐 token cross-entropy 的加總（符號沿用論文 Eq. 5）：
+
+$$L = \frac{1}{N}\sum_{j=1}^{N}\left(-\log l_{j+1} P_j^{\texttt{[Txt}_{j+1}\texttt{]}} -\ w\log f_j P_j^{\texttt{[EOS]}}\right)$$
+
+其中 $l_j$ 是語言 token 指示子（第 $j$ 個 token 是語言回應才為 1），$f_j$ 是串流指示子：當第 $j$ 個
+token 是某一影格的**最後一個** token、且下一個位置不是語言 token（$l_{j+1}=0$）時才為 1，也就是把
+EOS 監督只施加在「即將沉默」的影格上。$w$ 是平衡係數，預設 $w=1$。當每格只用 1 個 token 時，語言
+損失與串流損失在序列上的作用範圍如下圖標示。
+
+![LIVE 訓練方法：影格 token 與語言 token 依時間交錯，Streaming Loss 監督沉默影格輸出 EOS、LM Loss 監督該回答時刻的語言 token](imgs/fig4.png)
+
+### 資料引擎：把離線標註轉成串流對話
+
+上述訓練需要「影片流內的使用者查詢與助理回應」資料，但主流影片資料集大多只有離線的時間段標註。作者
+提出兩條資料生成路線。對 Ego4D narration 這種本身就以串流方式標註（標註者邊看 5 分鐘影片邊即時描述）
+的資料，直接沿用給人類標註者的指示當作訓練 prompt。對只有時間段標註的離線資料（如 COIN），則用 LLM
+合成對話：先準備一個涵蓋過去/現在/未來時態的問題模板庫，作者共準備了每類 50 題、合計 $N=150$ 條查詢；
+接著把時間軸標註整理成「time $t_a \sim t_b$: boiling the water」這樣的語言 prompt，把所有狀態轉變的
+關鍵時間點視為理想回應時刻，再讓 LLM 在每個關鍵時間點生成回應。訓練時隨機抽一條查詢、隨機插入到某個
+時間戳 $t_r$、丟掉 $t_r$ 之前的回應，每個樣本最多插入 3 條查詢。
+
+![LIVE 資料生成方法：把問題模板隨機插入影片時間軸，並將帶時間戳的 ground-truth 標註「曝露」給 LLM 以生成分時回應](imgs/fig3.png)
+
+### 模型架構與推論管線
+
+架構延續 LLaVA 的三件式：影像編碼器、MLP projector、語言模型。影像編碼器用在 DataComp-1B 上預訓練的
+CLIP ViT-L，以 2 FPS 抽取影格 embedding，形狀為 $(1+h_p\times w_p)\times c$（1 個 CLS token 加上平均
+池化後的空間 token）。論文正文實驗刻意設 $h_p=w_p=0$，也就是每格只用 1 個 CLS token，這是最省的設定，
+可在 4096 context window 內處理近半小時影片；釋出的 demo 模型則用 $1+3\times3=10$ 個 token/格以換取
+更細的對話細節。影格 token 經 MLP 投影後與語言 token 交錯輸入 Llama-2-7B-Chat 或 Llama-3-8B-Instruct，
+並在每個線性層加上 LoRA 做高效微調（rank 128、scaling 256）。
+
+推論端有三個工程設計。其一是 probability correction：因為 EOS 太常見會讓模型偏向沉默，作者引入門檻
+$\theta$，只有當 $P_j^{\texttt{[EOS]}} \ge \theta$ 才把 EOS 當下一個 token，實務上 $\theta$ 設在
+$0.5 \sim 0.8$ 明顯優於不設門檻。其二是 continuous key-value cache：影片逐格串流輸入，靠 KV cache
+免去每格重算，配合「傾向沉默」的訓練讓連續推論很有效率。其三是 encoding/decoding 平行化：CLIP ViT-L
+（307M）遠小於 7B/8B 的 LLM，兩者速度落差會導致跳格；作者用一個 FIFO queue 讓快的編碼器持續編碼、
+不必等慢的 LLM 解碼完，避免瓶頸。
+
+![LIVE 推論管線：影格串流輸入，維持 continuous KV cache，並把快編碼器與慢 LLM 平行化以避免跳格](imgs/fig5.png)
+
+### 一個帶真實數字的走查
+
+以論文預設的 VideoLLM-online-7B-v1（CLIP + Llama-2-7B-Chat，每格 1 個 CLS token）在一段 5 分鐘 Ego4D
+narration 上運作為例：@2 FPS 抽樣約產生 600 影格，每格 1 token，因此整段串流僅約 600 個影格 token，
+遠低於 4096 的 context 上限。假設在 $t_r$ 插入查詢「Remind me when X appears」，在 X 尚未出現的每個影格
+上，模型被監督在該影格最後一個 token 預測 EOS（保持沉默）；當 X 於 $t_2$ 出現時，模型才被監督輸出
+「appeared」這串語言 token。正因為沉默影格不佔序列，串流方法的平均訓練 token 長度只有 1694，相較
+per-frame streaming 的 6737 少了約 4 倍，訓練時間也從 22h 降到 12h。推論時設 $\theta \in [0.5, 0.8]$
+做 EOS 門檻校正，5 分鐘串流可在單張 A100 上以 18.2 GB 記憶體、平均 13.5 FPS 運作。
+
+下表是串流學習方法的消融（Ego4D Narration Stream 驗證集，7B-v1）。No Training 的 LM-PPL 高達 498.5、
+Fluency 幾乎為 0；interleaved 對話雖把 PPL 壓到 2.45，但 TimeDiff 仍有 6.47、幾乎不會沉默；per-frame
+streaming 把 TimeDiff 降到 2.52 卻犧牲了 PPL（3.34）。本文的 streaming 方法在三項指標上都最好，且訓練
+token 與成本與最省的 interleaved 相同。
+
+| Method | Objective | LM-PPL↓ | TimeDiff↓ | Fluency↑ | #Train Token↓ | Cost |
+|-|-|-|-|-|-|-|
+| No Training | n/a | 498.5 | 6.50 | 0.1% | n/a | n/a |
+| Interleaved Dialogue | Language Modeling | 2.45 | 6.47 | 11.1% | 1694 | 12h |
+| Per-frame for Streaming | LM (w/ EOS turns) | 3.34 | 2.52 | 37.7% | 6737 | 22h |
+| Streaming Dialogue (Ours) | LM + Streaming EOS | 2.43 | 2.32 | 42.6% | 1694 | 12h |
+
+效率消融同樣支持串流設計：interleaved 因每格都輸出語言而吃 34.4 GB、只有 1.5 FPS；per-frame streaming
+改善到 24.9 GB / 7.5 FPS；本文 streaming 因不在冗餘影格花 token、KV cache 較小，達到 18.2 GB / 13.5 FPS。
+
+| Method | Mem↓ | FPS↑ |
+|-|-|-|
+| Interleaved | 34.4G | 1.5 |
+| Per-frame Streaming | 24.9G | 7.5 |
+| Streaming | 18.2G | 13.5 |
+
+在離線 benchmark 上，作者宣稱在 end-to-end 模型中取得 SOTA。COIN 六項 Top-1 Accuracy 中，7B-v1 的 step
+recognition 為 59.8、8B-v1+ 更達 63.1，皆高於先前最佳的 VideoTaskGraph（57.2）；Ego4D LTA 的
+ED@Z=20（越低越好）Action 欄，8B-v1+ 為 0.884，優於同為 end-to-end 的 VideoLLM（0.921），但仍略遜於
+使用 egocentric 預訓練特徵、且串接多重複雜方法的非 end-to-end AntGPT（0.877）。
+
+| Method | COIN Step↑ | COIN Task↑ | Ego4D LTA Action ED↓ |
+|-|-|-|-|
+| VideoTaskGraph | 57.2 | 90.5 | n/a |
+| VideoLLM | n/a | n/a | 0.921 |
+| VideoLLM-online-7B-v1 | 59.8 | 92.1 | 0.897 |
+| VideoLLM-online-8B-v1+ | 63.1 | 92.7 | 0.884 |
+
+## 🧪 Critical Assessment
+
+### 問題是真需求，還是為方法量身打造的設定
+
+「always-on 影片助理」的動機是可信的：GPT-4o 當時的多模態互動仍需人聲觸發，逐格提醒/摘要/預測確實是
+未被滿足的能力。streaming EOS 這個「用不進序列的監督訊號教模型何時沉默」的想法也乾淨而有效，屬於實質
+創新而非改名包裝。但要留意的是，論文賴以立論的主要評測——Ego4D Narration Stream——高度貼合作者方法的
+強項：作者自己也承認 narration 文本「相對簡單，主要由主詞、動詞、受詞構成」，因此 LM-PPL 與 LG-Match
+才勉強適用。換句話說，這個串流基準是圍繞方法能發揮的簡單語言場景所定義的，對更複雜、free-form 的線上
+對話能力，論文明說現有指標「並不有效」並留待未來工作。這是一種評測邊界的自我圈定，需要讀者警覺。
+
+### 基線、消融與指標是否足夠
+
+正面看，消融相當完整：學習方法（interleaved / per-frame / streaming）、串流損失函數（CE vs OHEM vs
+Focal）、損失權重 $\tau$、以及記憶體/速度都各有一張表，且 CE、$\tau=1.0$ 的預設選擇有數據支撐。但有幾
+處缺口值得質疑。其一，TimeDiff、Fluency、LG-Match 三項核心指標全是作者自定義，沒有外部資料集或既有
+文獻的可比基準，讀者難以判斷 2.32 秒的 TimeDiff 在絕對意義上算好還是普通。其二，主要串流實驗只在單一
+資料集（Ego4D narration）驗證，COIN+Ego4D 的 free-form 設定僅作定性展示，缺乏跨資料集的量化外推。其三，
+所有數字看不到多次隨機種子的變異或信賴區間，像 $\tau=0.5/1.0/2.0$ 之間 Fluency 只差 0.2 個百分點這種
+差距，是否統計顯著並不明朗。
+
+### 離線 SOTA 的宣稱要打折扣看
+
+論文標題與敘事把「離線 benchmark SOTA」當作賣點，但表格裡的比較條件並不完全對等。作者的 SOTA 宣稱限定
+在「end-to-end 模型」這個子集：在 Ego4D LTA 上，真正最佳的 AntGPT（0.877）與 Palm 都被以灰字列在
+end-to-end 分隔線之下，理由是它們用了 egocentric 預訓練特徵與級聯方法。這個界定本身合理且有揭露，但把
+它讀成「無條件 SOTA」會失真——本文的 0.884 其實仍輸給既有非 end-to-end 方法。COIN 一側則加了「Not use
+HT100M」欄位來凸顯自身未用額外預訓練，這雖是公平性論述，也同時是縮小可比集合、讓自己更突出的框定方式。
+
+### 是否真的解決了宣稱的問題，以及現實相關性
+
+就「能否在單卡上以 >10 FPS 跑 5 分鐘串流並適時回應」這個工程目標而言，論文的證據（13.5 FPS、18.2 GB）
+是有說服力的，方法在其定義的任務上確實可用。但「解決 always-on 影片助理」這個更大的敘事仍有距離：正文
+實驗刻意用每格 1 token 的最省設定，作者自陳這會犧牲空間細節，需要更多空間 token 才能做好 zero-shot 的
+下游空間理解，而這正被列為未來工作；demo 用的 10 token/格設定則沒有進入量化評測。此外，資料引擎依賴
+Llama-2/3 為 COIN 標註「幻想」出對話回應，這些合成回應的正確性與偏誤沒有被系統性評估，可能把 LLM 的
+既有偏差引入監督訊號。因此比較穩妥的結論是：本文在一個定義清晰但相對狹窄的串流敘述任務上給出了漂亮且
+高效的解法，但距離其願景中通用、free-form 的即時助理，仍是一個有前景的起點而非終點。
+
+## 🔗 Related notes
+
+<!-- 目前 domains/vision_language 下無與串流影片對話直接相關且可解析的既有筆記，故保留標題留空。 -->

--- a/domains/vision_language/WhyFarLooksUp/README.md
+++ b/domains/vision_language/WhyFarLooksUp/README.md
@@ -1,4 +1,5 @@
-# WhyFarLooksUp — 空間表徵探測研究筆記
+# WhyFarLooksUp — Spatial Representation Probing Research Note
+> **English** | [繁體中文](./README.zh-TW.md)
 
 ## 📇 Academic Context
 
@@ -11,69 +12,69 @@
 | Official Code | https://github.com/cheolhong0916/contrastive-probing |
 | Venue Kind | paper |
 
-> 本筆記依據 arXiv e-print（arXiv id `2605.30161`，抓取於 2026-07-03）的 LaTeX 原始檔撰寫；`Venue` 欄記錄論文自述的投稿場所 ECCV 2026，其同儕審查與錄取狀態未在原文獨立佐證，正式版數據可能與此預印本略有差異。
+> This note is written from the LaTeX source of the arXiv e-print (arXiv id `2605.30161`, fetched on 2026-07-03); the `Venue` field records the paper's self-stated submission venue ECCV 2026, whose peer-review and acceptance status is not independently corroborated in the original text, and the official-version data may differ slightly from this preprint.
 
 ## First Principles
 
-### 透視投影如何把「上方」偷換成「遠方」
+### How perspective projection swaps "up" for "far"
 
-單張 RGB 照片只是 3D 場景的一個 2D 投影，模型要回答「椅子是否比桌子離相機更近」這類問題，只能從間接視覺線索反推空間結構。問題在於：日常照片裡存在一條穩定的相關性——地面上的物體，離觀察者越遠，在影像中就出現得越高（趨近地平線）。這條「仰角線索」（elevation cue）讓模型有機會走一條捷徑：被問到深度時，它其實部分是在讀物體的垂直位置，而非真的在推理 3D 幾何。作者把這種傾向命名為 vertical-distance entanglement（垂直—距離糾纏），也就是模型內部把 *above* 約等於 *far*、*below* 約等於 *close*。
+A single RGB photo is just a 2D projection of a 3D scene, and to answer a question like "is the chair closer to the camera than the table," a model can only infer the spatial structure indirectly from visual cues. The problem is that everyday photos contain a stable correlation: for objects on the ground, the farther they are from the observer, the higher they appear in the image (approaching the horizon). This "elevation cue" gives the model a chance to take a shortcut: when asked about depth, it is partly reading an object's vertical position rather than truly reasoning about 3D geometry. The authors name this tendency vertical-distance entanglement, i.e. the model internally treats *above* as roughly *far* and *below* as roughly *close*.
 
-![透視捷徑示意：位置越高被當成越遠，counter 樣本因此系統性失敗](imgs/teaser.png)
+![Perspective-shortcut illustration: the higher the position, the farther it is judged to be, so counter samples systematically fail](imgs/teaser.png)
 
-這條捷徑之所以危險，是因為 behavioral benchmark 只量「答對沒有」，卻看不到「怎麼答對的」。兩個在基準上分數相近的模型，內部機制可能完全不同：一個把空間關係編碼成結構化、可分離的方向，另一個只是依賴自然影像裡的相關線索，一旦分布偏移就變脆。要區分這兩者，必須直接檢視空間資訊在模型內部是怎麼被表徵的。
+This shortcut is dangerous because a behavioral benchmark only measures "did it answer correctly," but cannot see "how it answered correctly." Two models with similar scores on the benchmark may have completely different internal mechanisms: one encodes spatial relations as structured, separable directions, the other merely relies on correlated cues in natural images and becomes fragile once the distribution shifts. To distinguish the two, one must directly examine how spatial information is represented inside the model.
 
-### 用 consistent / counter 切分把捷徑變成可量測的差距
+### Using a consistent / counter split to turn the shortcut into a measurable gap
 
-作者把所有跟深度有關的樣本，依「真實答案是否與仰角捷徑一致」切成兩組：farther 物體在影像中較高就是 consistent，farther 物體反而較低就是 counter。實作上比較兩個被詢問物體的垂直中心座標，較遠者 $y$ 值較小（位置較高）即為 consistent，否則為 counter。如果模型沒有糾纏，兩組準確率應該相近；一旦出現系統性差距，就是它在吃垂直位置捷徑的證據。
+The authors split all depth-related samples into two groups by "whether the true answer aligns with the elevation shortcut": if the farther object is higher in the image, it is consistent; if the farther object is instead lower, it is counter. In practice they compare the vertical center coordinates of the two queried objects; if the farther one has a smaller $y$ value (higher position), it is consistent, otherwise counter. If the model has no entanglement, the two groups' accuracies should be close; once a systematic gap appears, it is evidence that the model is exploiting the vertical-position shortcut.
 
-![consistent 與 counter 樣本：前者遠物較高、後者遠物較低](imgs/consistent_counter.png)
+![Consistent vs counter samples: the former has the far object higher, the latter has the far object lower](imgs/consistent_counter.png)
 
-真實基準的分布本身就嚴重偏向 consistent。在 EmbSpatial-Bench 裡 consistent 佔 976 題（80.9%）、counter 只有 129 題（10.7%）；CV-Bench-3D 則是 consistent 363 題（60.5%）、counter 65 題（10.8%）；其餘為 ambiguous（$\Delta y$ 小於影像高度 5%）。這正好複製了真實照片的自然統計：大多數場景裡遠物確實比較高。於是所有模型在 counter 子集上一致地大幅退步——例如 Qwen2.5-VL-3B 微調 2M 樣本後，在 EmbSpatial-Bench 的 consistent 上有 60.9%，counter 卻只剩 24.0%，落差高達 36.9 個百分點；而且這個現象跨越 Molmo、NVILA、Qwen2.5-VL 三個家族、跨越模型大小與微調資料量都成立。
+The distribution of real benchmarks is itself severely biased toward consistent. In EmbSpatial-Bench, consistent accounts for 976 questions (80.9%) and counter only 129 (10.7%); in CV-Bench-3D, consistent is 363 questions (60.5%) and counter 65 (10.8%); the rest are ambiguous ($\Delta y$ smaller than 5% of the image height). This exactly replicates the natural statistics of real photos: in most scenes the far object is indeed higher. As a result, all models consistently and substantially regress on the counter subset — for example, after fine-tuning Qwen2.5-VL-3B on 2M samples, it has 60.9% on EmbSpatial-Bench's consistent but only 24.0% on counter, a gap as large as 36.9 percentage points; and this phenomenon holds across the three families Molmo, NVILA, Qwen2.5-VL, across model sizes, and across fine-tuning data volumes.
 
-### SpatialTunnel:在合成走廊裡把 2D 高度和 3D 深度解耦
+### SpatialTunnel: decoupling 2D height from 3D depth in a synthetic corridor
 
-真實照片會把多個深度線索（垂直位置、視覺大小、遮擋）攪在一起，很難單獨隔離某一個。作者因此用 Blender 造了一個 tunnel（單點透視走廊）合成資料集：牆、天花板與地板對相機光軸對稱，物體可以貼在走廊內壁任意位置。關鍵在於，走廊頂端和底端的物體可以與相機等距，於是「越高越遠」的捷徑在幾何上直接失效。每個物體以深度 $z$ 與截面角度 $\theta$ 參數化，固定 $z$ 只掃 $\theta$，就能在不改變深度排序的前提下讓物體在影像裡上下左右移動，構成一組配對的 counterfactual。
+Real photos entangle multiple depth cues (vertical position, visual size, occlusion) together, making it hard to isolate any single one. The authors therefore use Blender to build a tunnel (single-point-perspective corridor) synthetic dataset: the walls, ceiling, and floor are symmetric about the camera's optical axis, and objects can be attached anywhere on the corridor's inner walls. The key is that objects at the top and bottom ends of the corridor can be equidistant from the camera, so the "higher is farther" shortcut directly fails geometrically. Each object is parameterized by depth $z$ and cross-section angle $\theta$; fixing $z$ and sweeping only $\theta$ lets the object move up/down/left/right in the image without changing the depth ordering, forming a paired set of counterfactuals.
 
-![SpatialTunnel 固定兩物深度、掃描截面角度,使 2D 佈局獨立於深度排序而變化](imgs/spatialtunnel.png)
+![SpatialTunnel fixes the depth of two objects and sweeps the cross-section angle, making the 2D layout vary independently of the depth ordering](imgs/spatialtunnel.png)
 
-實作上把截面離散成 16 個角度，對兩個物體形成 $16\times16$ 的 $(\theta_1,\theta_2)$ 網格；每個配置渲染 12 個隨機化場景（形狀、顏色、大小、光照都隨機），得到 $16\times16\times12=3{,}072$ 張影像，配上 4 種問句模板即 $12{,}288$ 個問題。評分不看生成的字面答案，而是取第一個生成 token 上 `Yes` 與 `No` 的 logits，定義：
+In practice the cross-section is discretized into 16 angles, forming a $16\times16$ grid of $(\theta_1,\theta_2)$ for two objects; each configuration renders 12 randomized scenes (shape, color, size, and lighting are all randomized), giving $16\times16\times12=3{,}072$ images, paired with 4 question templates for $12{,}288$ questions. The scoring does not look at the literal generated answer but takes the logits of `Yes` and `No` at the first generated token, defining:
 
 $$
 p=\sigma\!\bigl(\ell_{\texttt{Yes}}-\ell_{\texttt{No}}\bigr)
 $$
 
-單題正確度 $v=p$（若標準答案是 `Yes`）或 $v=1-p$（若為 `No`）。再依 consistent / counter 切分報告四個指標：平均正確度 $v$、consistent 正確度 $v_\text{cons}$、counter 正確度 $v_\text{ctr}$，以及量化糾纏強度的準確率落差 $\Delta=v_\text{cons}-v_\text{ctr}$；沒有方向性偏差的模型應該有 $\Delta\approx0$。
+The per-question correctness is $v=p$ (if the ground truth is `Yes`) or $v=1-p$ (if `No`). Then, split by consistent / counter, four metrics are reported: mean correctness $v$, consistent correctness $v_\text{cons}$, counter correctness $v_\text{ctr}$, and the accuracy gap that quantifies entanglement strength, $\Delta=v_\text{cons}-v_\text{ctr}$; a model with no directional bias should have $\Delta\approx0$.
 
-因為 $16\times16$ 網格窮舉了兩物的所有截面角度組合，可以把每個格子的正確度畫成熱力圖，直接看偏差落在哪些配置上。下圖用 Molmo-7B 的三個微調規模（base → 400k → 2M）並排 consistent 與 counter 兩張熱力圖：consistent 側的紅色（高正確度）區域隨資料規模穩定擴張、到 2M 已大面積深紅；counter 側則相反，base 時整片偏淡（接近亂猜），400k 掉到最深的藍（糾纏最嚴重、落差最大），到 2M 雖回升成大片紅色，但紅得比 consistent 側淺、且夾著一條偏白/藍的帶——也就是原文說的「部分回升，但 counter 依舊實質更難」。這張圖把「加資料主要在補 consistent、counter 只是被動跟上」的機制攤在同一個色階上。
+Because the $16\times16$ grid exhaustively enumerates all cross-section angle combinations of the two objects, the correctness of each cell can be plotted as a heatmap, directly showing which configurations the bias falls on. The figure below places, side by side, the consistent and counter heatmaps for Molmo-7B's three fine-tuning scales (base → 400k → 2M): on the consistent side the red (high-correctness) region stably expands with data scale and becomes a large deep-red area by 2M; the counter side is the opposite, being pale overall at base (close to random guessing), dropping to the deepest blue at 400k (most severe entanglement, largest gap), and by 2M recovering to a large red area, but redder-but-lighter than the consistent side and interlaced with a whitish/blue band — i.e. what the original text calls "partial recovery, but counter remains substantially harder." This figure lays bare, on the same color scale, the mechanism that "adding data mainly fills in consistent, and counter only passively follows."
 
-![Molmo-7B 在 SpatialTunnel 的正確度熱力圖：consistent 側紅區隨 base→400k→2M 擴張，counter 側 400k 最深藍、2M 部分回升但仍淺於 consistent](imgs/heatmap_compare_molmo_consistent.png)
+![Molmo-7B's correctness heatmap on SpatialTunnel: the consistent side's red region expands with base→400k→2M, while the counter side is deepest blue at 400k and partially recovers at 2M but is still lighter than consistent](imgs/heatmap_compare_molmo_consistent.png)
 
-![同上的 counter 子集：base 近亂猜、400k 落至最深藍（最大落差）、2M 回升為大片紅但仍夾雜偏白/藍帶](imgs/heatmap_compare_molmo_counter.png)
+![The counter subset of the above: near-random guessing at base, dropping to the deepest blue at 400k (largest gap), recovering to a large red area at 2M but still interlaced with a whitish/blue band](imgs/heatmap_compare_molmo_counter.png)
 
-### 走一遍 Qwen2.5-VL-3B 的 SpatialTunnel 聚合結果(worked example)
+### Walking through Qwen2.5-VL-3B's aggregated SpatialTunnel result (worked example)
 
-以基礎版 Qwen2.5-VL-3B 在完整 SpatialTunnel 評估上的聚合結果為例，具體看數字怎麼落地。走廊裡每張圖放兩個固定深度的物體，問「obj$_1$ 是否比 obj$_2$ 離相機更遠」；模型讀入 RGB 影像與問句、跑前向，在第一個生成位置讀出 $\ell_{\texttt{Yes}}$ 與 $\ell_{\texttt{No}}$，代入 $p=\sigma(\ell_{\texttt{Yes}}-\ell_{\texttt{No}})$ 得到單題信心。把 $16\times16$ 網格、12 個隨機場景與 4 種問句模板上所有 consistent 樣本的 $v$ 平均，得到 $v_\text{cons}=0.776$；所有 counter 樣本平均則只有 $v_\text{ctr}=0.360$，於是 $\Delta=+0.416$——這是全表最大的糾纏落差（這些是整個資料集的聚合統計，不是單一格子或單次前向的值），顯示這個基礎模型幾乎是靠「高即遠」在作答，而非真的比較深度。作為對照，同屬 NVILA 基座、但吃了 20M 以上含深度監督資料的 RoboRefer-2B-SFT，在同一測試上 $v=0.793$、$\Delta$ 只有 $+0.046$；資料規模化到極致的 Qwen3-VL-235B 則 $v=0.908$、$\Delta=+0.068$。同一個「二選一深度題」，糾纏可以從 0.416 一路壓到 0.05 附近，差別不在題目而在表徵。
+Take the aggregated result of the base Qwen2.5-VL-3B on the full SpatialTunnel evaluation as an example, to concretely see how the numbers land. Each image in the corridor places two objects at fixed depths, asking "is obj$_1$ farther from the camera than obj$_2$"; the model reads in the RGB image and the question, runs a forward pass, reads out $\ell_{\texttt{Yes}}$ and $\ell_{\texttt{No}}$ at the first generated position, and substitutes into $p=\sigma(\ell_{\texttt{Yes}}-\ell_{\texttt{No}})$ to get the per-question confidence. Averaging $v$ over all consistent samples across the $16\times16$ grid, 12 randomized scenes, and 4 question templates gives $v_\text{cons}=0.776$; averaging over all counter samples gives only $v_\text{ctr}=0.360$, so $\Delta=+0.416$ — this is the largest entanglement gap in the whole table (these are aggregated statistics over the entire dataset, not the value of a single cell or a single forward pass), showing that this base model answers almost entirely by "high means far" rather than by truly comparing depth. As a contrast, RoboRefer-2B-SFT, which shares the NVILA base but was trained on over 20M samples including depth supervision, has $v=0.793$ and $\Delta$ of only $+0.046$ on the same test; the scale-to-the-extreme Qwen3-VL-235B has $v=0.908$ and $\Delta=+0.068$. On the same "two-way depth question," entanglement can be pushed from 0.416 all the way down to around 0.05 — the difference lies not in the question but in the representation.
 
-### contrastive probing:用 delta vector 直接讀出空間軸
+### contrastive probing: reading out the spatial axis directly with a delta vector
 
-要看內部表徵，作者設計了 contrastive probing。給定一張圖，構造一對只差在物體順序的問句，例如把「A 在 B 的左邊還是右邊」換成「B 在 A 的左邊還是右邊」，於是標準答案剛好被反轉（left 變 right）。對每個問句取固定中間層 $L^*$ 的最後一個 token 隱狀態 $h_q\in\mathbb{R}^d$，定義 delta vector 為交換前後的位移 $\delta=h_{q_2}-h_{q_1}$；跨大量影像重複，就得到每個空間類別（above、below、far、close、left、right）的一組 delta 向量，把共通的視覺成分抵消掉，只剩下空間方向的潛在編碼。
+To look at the internal representation, the authors design contrastive probing. Given an image, they construct a pair of questions differing only in object order, e.g. changing "is A to the left or right of B" to "is B to the left or right of A," so that the ground-truth answer is exactly reversed (left becomes right). For each question, take the last-token hidden state $h_q\in\mathbb{R}^d$ at a fixed intermediate layer $L^*$, and define the delta vector as the displacement before and after the swap, $\delta=h_{q_2}-h_{q_1}$; repeating across many images gives a set of delta vectors for each spatial category (above, below, far, close, left, right), which cancels out the common visual components and leaves only the latent encoding of the spatial direction.
 
-![contrastive probing:交換物體順序取隱狀態差,得到 delta 向量](imgs/contrastive_probing.png)
+![contrastive probing: swapping object order and taking the hidden-state difference gives the delta vector](imgs/contrastive_probing.png)
 
-在 delta 向量上定義兩個指標。第一個是 axis coherence（軸一致性）：對每條軸（水平、垂直、距離），把兩個相反類別的 delta 集中起來，並對相反那一側取負號使全部朝同一正向（$\tilde{\delta}$），再算兩兩餘弦相似度的平均：
+Two metrics are defined on the delta vectors. The first is axis coherence: for each axis (horizontal, vertical, distance), gather the deltas of the two opposite categories, negate the opposite side so all point in the same positive direction ($\tilde{\delta}$), and compute the mean of pairwise cosine similarities:
 
 $$
 \mathrm{Coh}_{\mathrm{axis}} = \frac{2}{N(N-1)} \sum_{i < j} \cos\!\bigl(\tilde{\delta}^{(i)},\; \tilde{\delta}^{(j)}\bigr)
 $$
 
-高一致性代表模型把該軸編碼成一個穩定、方向一致的向量。第二個是 VD-Entanglement Index（VD-EI），對 above、below、far、close 各算平均 delta $\mu_c$，量測垂直與距離兩軸的方向重疊：
+High coherence means the model encodes that axis as a stable, direction-consistent vector. The second is the VD-Entanglement Index (VD-EI): computing the mean delta $\mu_c$ for each of above, below, far, close, it measures the directional overlap of the vertical and distance axes:
 
 $$
 \mathrm{VD\text{-}EI} = \tfrac{1}{4}\bigl[\cos(\mu_{\text{above}},\mu_{\text{far}}) + \cos(\mu_{\text{below}},\mu_{\text{close}}) - \cos(\mu_{\text{above}},\mu_{\text{close}}) - \cos(\mu_{\text{below}},\mu_{\text{far}})\bigr]
 $$
 
-前兩項是透視一致的配對（above↔far、below↔close），後兩項是透視相反的配對；VD-EI 為正，代表垂直與距離表徵正如透視投影預測地耦合在一起，為零則代表兩軸獨立。作者在 EmbSpatial-Bench 影像上、於各家族固定的一層抽取隱狀態；分析層落在網路約 71% 到 93% 深度處（Molmo $L^*{=}23$／共 32 層 ≈72%、NVILA $L^*{=}20$／共 28 層 ≈71%、Qwen2.5-VL $L^*{=}28$／共 36 層 ≈78%、Qwen3-VL-235B $L^*{=}87$／共 94 層 ≈93%）。前三個中小模型落在約 71–78% 的中後段，符合「空間表徵在中段層成形、末段層轉為輸出專用」的既有觀察；Qwen3-VL-235B 則是例外——原文明說它三軸的連貫表徵「很晚才形成」，因此選層被推到 93% 深度，作者推測與其 94 層 MoE 架構延後穩定空間表徵的形成有關。核心流程可寫成：
+The first two terms are perspective-consistent pairings (above↔far, below↔close), and the last two are perspective-opposite pairings; a positive VD-EI means the vertical and distance representations are coupled exactly as perspective projection predicts, and zero means the two axes are independent. The authors extract hidden states on EmbSpatial-Bench images at a fixed layer per family; the analysis layer falls at roughly 71% to 93% depth of the network (Molmo $L^*{=}23$ / 32 layers ≈72%, NVILA $L^*{=}20$ / 28 layers ≈71%, Qwen2.5-VL $L^*{=}28$ / 36 layers ≈78%, Qwen3-VL-235B $L^*{=}87$ / 94 layers ≈93%). The first three small-to-medium models fall at about 71–78%, in the mid-to-late range, consistent with the existing observation that "spatial representations form in the middle layers and the last layers turn output-specific"; Qwen3-VL-235B is the exception — the original text explicitly says its coherent representation for the three axes "forms very late," so the selected layer is pushed to 93% depth, and the authors speculate this relates to its 94-layer MoE architecture delaying the formation of a stable spatial representation. The core procedure can be written as:
 
 ```python
 # 每張圖建一組最小對比對:交換兩物體順序,標準答案被反轉
@@ -86,9 +87,9 @@ delta = h2 - h1                                          # delta vector δ
 # above/below/far/close 的平均 delta 之間算餘弦 -> VD-EI
 ```
 
-### 距離軸最弱,而它的成長預測 counter 穩健度
+### The distance axis is the weakest, and its growth predicts counter robustness
 
-把三條軸的一致性攤開來看，結論很乾脆：距離軸一致性 $\mathrm{Coh}_\mathrm{D}$ 在每一個模型、每一個訓練規模上都是三軸中最低的。微調會把垂直一致性拉得很高（Molmo 從 0.23 到 0.57、Qwen 從 0.29 到 0.59），但 $\mathrm{Coh}_\mathrm{D}$ 的成長幅度小得多。下表節錄幾個代表性列（完整表見原文 Table 5）：
+Laying out the coherence of the three axes, the conclusion is clean: the distance-axis coherence $\mathrm{Coh}_\mathrm{D}$ is the lowest of the three axes on every model and every training scale. Fine-tuning pulls the vertical coherence very high (Molmo from 0.23 to 0.57, Qwen from 0.29 to 0.59), but $\mathrm{Coh}_\mathrm{D}$ grows much less. The table below excerpts a few representative rows (see the original Table 5 for the full table):
 
 | Model | $\mathrm{Coh}_\mathrm{H}$ | $\mathrm{Coh}_\mathrm{V}$ | $\mathrm{Coh}_\mathrm{D}$ | VD-EI |
 |-|-|-|-|-|
@@ -100,54 +101,54 @@ delta = h2 - h1                                          # delta vector δ
 | Qwen2.5-3B (base) | 0.367 | 0.293 | 0.043 | 0.457 |
 | Qwen2.5-3B (+2M) | 0.485 | 0.586 | 0.052 | 0.472 |
 
-真正有意思的是 $\mathrm{Coh}_\mathrm{D}$ 與行為穩健度的連動。當距離一致性隨資料規模成長，counter 準確率會跟著上升：NVILA 的 $\mathrm{Coh}_\mathrm{D}$ 從 0.052 翻倍到 0.104，EmbSpatial-Bench counter 準確率從 27.1% 升到 41.1%；反之 Qwen2.5-VL 的 $\mathrm{Coh}_\mathrm{D}$ 幾乎不動（0.043→0.052），counter 準確率反而從 32.6% 掉到 24.0%，落差越拉越大。換句話說，距離表徵沒長出來，繼續加資料並不會解決糾纏。
+What is truly interesting is the linkage between $\mathrm{Coh}_\mathrm{D}$ and behavioral robustness. When the distance coherence grows with data scale, the counter accuracy rises with it: NVILA's $\mathrm{Coh}_\mathrm{D}$ doubles from 0.052 to 0.104, and its EmbSpatial-Bench counter accuracy rises from 27.1% to 41.1%; conversely, Qwen2.5-VL's $\mathrm{Coh}_\mathrm{D}$ barely moves (0.043→0.052), and its counter accuracy instead drops from 32.6% to 24.0%, with the gap widening. In other words, if the distance representation does not grow, continuing to add data does not resolve the entanglement.
 
-![Counter 準確率對距離一致性:Molmo、NVILA 沿右上軌跡上升,Qwen 卡在低 CohD,RoboRefer 位於右上角](imgs/cohd_vs_counter_acc.png)
+![Counter accuracy vs distance coherence: Molmo and NVILA rise along an upper-right trajectory, Qwen is stuck at low CohD, and RoboRefer is in the upper-right corner](imgs/cohd_vs_counter_acc.png)
 
-換一個角度、把 $\mathrm{Coh}_\mathrm{D}$（縱軸）對 VD-EI（橫軸）攤開，同一個 NVILA 家族的內部幾何就更清楚：一般微調變體（80k→2M 的橘點，帶箭頭標出規模化軌跡）全擠在圖的右下角——高 VD-EI（約 0.56–0.64）、低 $\mathrm{Coh}_\mathrm{D}$（約 0.05–0.09），也就是垂直與距離仍高度糾纏、距離軸還沒長好；RoboRefer（深紅點）則獨自落在左上角，是全家族唯一同時做到低糾纏與高距離一致性的點。要注意這張散點圖是各模型在圖用選層上算出的，數值與正文 Table 4 逐列報告的選層值略有出入（例如 RoboRefer 圖上約 $\mathrm{Coh}_\mathrm{D}\approx0.17$／VD-EI$\approx0.38$，表列為 0.182／0.362；NVILA-2M 圖上約 0.09／0.56，表列為 0.104／0.550），但兩者呈現的相對結構一致。
+From another angle, laying out $\mathrm{Coh}_\mathrm{D}$ (vertical axis) against VD-EI (horizontal axis) makes the internal geometry of the same NVILA family clearer: the ordinary fine-tuned variants (the orange dots from 80k→2M, with arrows marking the scaling trajectory) all cluster in the lower-right corner — high VD-EI (about 0.56–0.64), low $\mathrm{Coh}_\mathrm{D}$ (about 0.05–0.09), i.e. vertical and distance are still highly entangled and the distance axis has not yet grown; RoboRefer (the dark-red dot) sits alone in the upper-left corner, the only point in the whole family that simultaneously achieves low entanglement and high distance coherence. Note that this scatter plot is computed at each model's plot-selected layer, and the values differ slightly from the per-row selected-layer values reported in the main-text Table 4 (e.g. RoboRefer is about $\mathrm{Coh}_\mathrm{D}\approx0.17$ / VD-EI$\approx0.38$ on the plot vs 0.182 / 0.362 in the table; NVILA-2M is about 0.09 / 0.56 on the plot vs 0.104 / 0.550 in the table), but the relative structure the two present is consistent.
 
-![CohD 對 VD-EI 散點:NVILA 一般微調變體聚在右下角(高 VD-EI、低 CohD),RoboRefer 深紅點獨佔左上角(低 VD-EI、高 CohD)](imgs/cohd_vdei.png)
+![CohD vs VD-EI scatter: NVILA's ordinary fine-tuned variants cluster in the lower-right corner (high VD-EI, low CohD), and RoboRefer's dark-red dot occupies the upper-left corner alone (low VD-EI, high CohD)](imgs/cohd_vdei.png)
 
-而且 $\mathrm{Coh}_\mathrm{D}$ 不只是某個基準的內部產物。在 SpatialTunnel 上計算的 $\mathrm{Coh}_\mathrm{D}$，與另外兩個基準的 counter 準確率跨域相關：對 EmbSpatial-Bench 是 $\rho=0.759$、對 CV-Bench-3D 是 $\rho=0.804$（皆 $p<10^{-3}$）。這種跨域一致性支持「距離一致性捕捉到一種可重用的表徵訊號，而非某個資料集的計算假象」。
+Moreover, $\mathrm{Coh}_\mathrm{D}$ is not merely an internal product of some benchmark. The $\mathrm{Coh}_\mathrm{D}$ computed on SpatialTunnel correlates across domains with the counter accuracy of the other two benchmarks: $\rho=0.759$ for EmbSpatial-Bench and $\rho=0.804$ for CV-Bench-3D (both $p<10^{-3}$). This cross-domain consistency supports that "distance coherence captures a reusable representational signal rather than a computational artifact of some dataset."
 
-進一步把 $\mathrm{Coh}_\mathrm{D}$ 分別在合成走廊（SpatialTunnel）與真實影像（EmbSpatial-Bench）上重算並排比較，可以看到雖然兩域的絕對值不同（合成走廊普遍偏高），但每個家族內部的相對排序大致保留——下圖紅框標出的 NVILA 家族，其 RoboRefer $>$ 2M $>$ 400k$\approx$800k $>$ 80k $>$ base 的次序在合成與真實兩域完全一致。這佐證了「$\mathrm{Coh}_\mathrm{D}$ 的絕對大小受環境影響，但在相同資料條件下提供可靠的相對比較」。
+Further, recomputing $\mathrm{Coh}_\mathrm{D}$ separately on the synthetic corridor (SpatialTunnel) and real images (EmbSpatial-Bench) and comparing side by side, one can see that although the absolute values of the two domains differ (the synthetic corridor is generally higher), the relative ordering within each family is largely preserved — for the NVILA family boxed in red in the figure below, its order RoboRefer $>$ 2M $>$ 400k$\approx$800k $>$ 80k $>$ base is completely consistent across the synthetic and real domains. This corroborates that "the absolute magnitude of $\mathrm{Coh}_\mathrm{D}$ is affected by the environment, but under the same data conditions it provides a reliable relative comparison."
 
-![合成走廊(灰條)與真實 EmbSpatial-Bench(紅點)上的 CohD 並排:絕對值不同但家族內排序保留,紅框標出 NVILA 家族在兩域排序一致](imgs/cross_domain_distance_coherence.png)
+![CohD side by side on the synthetic corridor (gray bars) and real EmbSpatial-Bench (red dots): the absolute values differ but the within-family ordering is preserved, and the red box marks the NVILA family whose ordering is consistent across both domains](imgs/cross_domain_distance_coherence.png)
 
-### 什麼樣的表徵才算「強」
+### What kind of representation counts as "strong"
 
-把同基座的 NVILA 系列與 RoboRefer 放在一起做 PCA，可以直接看到差異。基礎 NVILA 的距離 delta 向量塌縮在原點附近，根本沒形成一條可辨認的軸；微調到 2M 開始出現方向擴散，但垂直與距離的群集仍然重疊；RoboRefer 則是三條軸各自乾淨地分成獨立群集、對齊到不同主成分。量化上，NVILA 整條規模化軌跡的 $\mathrm{Coh}_\mathrm{D}$ 只有邊際成長、VD-EI 一直高掛在 0.54–0.64；RoboRefer 佔據一塊獨特區域——家族內最高的 $\mathrm{Coh}_\mathrm{D}$（0.182）與最低的 VD-EI（0.362），對應到 59.7% 的 EmbSpatial-Bench counter 準確率，遠高於 NVILA-2M 的 41.1%。
+Putting the same-base NVILA series together with RoboRefer for a PCA, one can directly see the difference. Base NVILA's distance delta vectors collapse near the origin and form no identifiable axis at all; fine-tuning to 2M starts to show directional spread, but the vertical and distance clusters still overlap; RoboRefer, on the other hand, has the three axes cleanly separated into independent clusters, aligned to different principal components. Quantitatively, NVILA's entire scaling trajectory has only a marginal growth in $\mathrm{Coh}_\mathrm{D}$ and a VD-EI persistently high at 0.54–0.64; RoboRefer occupies a distinctive region — the highest $\mathrm{Coh}_\mathrm{D}$ in the family (0.182) and the lowest VD-EI (0.362), corresponding to 59.7% EmbSpatial-Bench counter accuracy, far above NVILA-2M's 41.1%.
 
-![各模型 delta 向量的 PCA:Molmo/NVILA/Qwen 的 2M 版距離軸仍糾纏,RoboRefer 與 Qwen3 三軸清楚分離](imgs/pca_delta.png)
+![PCA of each model's delta vectors: the 2M versions of Molmo/NVILA/Qwen still have entangled distance axes, while RoboRefer and Qwen3 have the three axes clearly separated](imgs/pca_delta.png)
 
-也因此，行為準確率單看一個數字並不可靠：NVILA(2M) 在 CV-3D Depth 有 93.8%，到 BLINK Spatial Relation 卻掉到 62.9%；Qwen(2M) 在 BLINK Spatial Relation 有 78.3%，到 CV-3D Distance 又只剩 52.2%。相對地，表徵結構最乾淨的 RoboRefer 與 Qwen3-VL-235B 在各基準上一致地高。作者據此主張，高 $\mathrm{Coh}_\mathrm{D}$（搭配低 VD-EI 作為互補訊號）可以當成「這次訓練有沒有真的改善空間表徵」的實用診斷。不過作者也明說，RoboRefer 同時改了訓練規模與監督方式，因此只當作示意性的參照，而非把好處歸因於單一因素。
+Because of this, a single behavioral-accuracy number alone is unreliable: NVILA(2M) has 93.8% on CV-3D Depth but drops to 62.9% on BLINK Spatial Relation; Qwen(2M) has 78.3% on BLINK Spatial Relation but only 52.2% on CV-3D Distance. In contrast, RoboRefer and Qwen3-VL-235B, with the cleanest representation structure, are consistently high across benchmarks. The authors thus argue that a high $\mathrm{Coh}_\mathrm{D}$ (with a low VD-EI as a complementary signal) can serve as a practical diagnostic for "whether this training truly improved the spatial representation." However, the authors also explicitly state that RoboRefer changed both the training scale and the supervision type, so it is only used as an illustrative reference rather than attributing the benefit to a single factor.
 
 ## 🧪 Critical Assessment
 
-### 這個捷徑是真實缺陷,還是被基準分布放大的假象
+### Is this shortcut a real defect, or an artifact amplified by the benchmark distribution
 
-論文最有價值的一步，其實是先看穿自己的證據可能有問題。真實基準本身嚴重偏 consistent（EmbSpatial 80.9%、CV-Bench-3D 60.5%），所以「counter 掉分」有兩種解釋：模型內化了偏差，或只是評測集偏斜。作者用 SpatialTunnel 這個平衡合成集把後者切掉，在幾何上對稱、consistent 與 counter 均衡時仍看到正的 $\Delta$，這讓「model-intrinsic」的主張站得住腳，方法論上是誠實且到位的。可補強的是：counter 子集在真實基準上樣本量很小（EmbSpatial 只有 129 題、CV-Bench-3D 只有 65 題），單一模型 counter 準確率的信賴區間會相當寬。以 Qwen2.5-VL-3B(+2M) 為例做個粗估：EmbSpatial counter 24.0%（$n=129$）的常態近似 95% 信賴區間約為 $[16.6\%, 31.4\%]$，CV-Bench-3D counter 53.8%（$n=65$）約為 $[41.7\%, 65.9\%]$（區間為本筆記依二項常態近似自行推算，非原文報告值）——區間寬達 15–24 個百分點。論文把不少 3–5 個百分點的差異拿來敘事，這類小樣本比較的統計穩定度值得保留。
+The paper's most valuable step is actually to first see through that its own evidence may be problematic. Real benchmarks are themselves severely biased toward consistent (EmbSpatial 80.9%, CV-Bench-3D 60.5%), so "counter loses points" has two explanations: the model internalized the bias, or the evaluation set is simply skewed. The authors use SpatialTunnel, a balanced synthetic set, to cut off the latter, and still see a positive $\Delta$ when the geometry is symmetric and consistent and counter are balanced, which makes the "model-intrinsic" claim tenable and is methodologically honest and to the point. What could be strengthened: the counter subset has very small sample sizes on real benchmarks (only 129 questions for EmbSpatial, only 65 for CV-Bench-3D), so the confidence interval of a single model's counter accuracy would be quite wide. Take Qwen2.5-VL-3B(+2M) as a rough estimate: the normal approximation 95% confidence interval for EmbSpatial counter 24.0% ($n=129$) is about $[16.6\%, 31.4\%]$, and for CV-Bench-3D counter 53.8% ($n=65$) is about $[41.7\%, 65.9\%]$ (the intervals are derived by this note using a binomial normal approximation, not reported in the original text) — intervals as wide as 15–24 percentage points. The paper uses quite a few 3–5 percentage-point differences for its narrative, and the statistical stability of such small-sample comparisons is worth reserving judgment on.
 
-### 把 RoboRefer 當「強表徵」對照是否公平
+### Is treating RoboRefer as the "strong representation" reference fair
 
-整篇的正向錨點幾乎都壓在 RoboRefer 與 Qwen3-VL-235B 身上，但兩者都不是乾淨的受控變因。RoboRefer 相對 NVILA 系列同時動了資料規模（20M+）與監督型態（含 RGB-D 深度監督），Qwen3-VL-235B 更是換了一個數量級的預訓練規模。作者自己也承認 RoboRefer「只當示意參照」，這是恰當的謹慎；但論文的核心敘事（結構化表徵帶來穩健度）在很大程度上依賴這兩個混淆了多個因素的點，真正受控的家族內證據其實只有「$\mathrm{Coh}_\mathrm{D}$ 隨規模成長 ↔ counter 上升」這條，且它在 Qwen 家族上是反例。把單一深度監督模型當成「結構化表徵」的存在性證明可以，但要支撐「這是達成穩健度的路徑」則證據偏薄。
+Almost all of the paper's positive anchors rest on RoboRefer and Qwen3-VL-235B, but neither is a clean controlled variable. RoboRefer, relative to the NVILA series, changed both the data scale (20M+) and the supervision type (including RGB-D depth supervision), and Qwen3-VL-235B changed the pretraining scale by an order of magnitude. The authors themselves admit RoboRefer is "only an illustrative reference," which is appropriate caution; but the paper's core narrative (structured representation brings robustness) largely depends on these two points that confound multiple factors, and the truly controlled within-family evidence is really only the single thread of "$\mathrm{Coh}_\mathrm{D}$ grows with scale ↔ counter rises," which is a counterexample on the Qwen family. Using a single depth-supervised model as an existence proof of a "structured representation" is fine, but supporting "this is the path to achieving robustness" is thinly evidenced.
 
-### CohD 與穩健度:相關性被當成因果的風險
+### CohD and robustness: the risk of treating correlation as causation
 
-$\mathrm{Coh}_\mathrm{D}$ 與 counter 準確率的關係，通篇是相關性證據（跨域 $\rho=0.759/0.804$、家族內同向軌跡），而敘事語氣時常滑向因果（「形成連貫的距離表徵使模型更穩健」）。這裡有循環的疑慮：$\mathrm{Coh}_\mathrm{D}$ 與 counter 準確率都在 EmbSpatial-Bench 的同一批影像上計算，兩者共享輸入分布，跨域驗證雖然緩解了一部分，但相關並不排除「兩者同為某個更根本能力的共變量」。論文沒有做介入式實驗（例如直接沿距離軸編輯表徵、或在訓練中顯式提升 $\mathrm{Coh}_\mathrm{D}$ 再看 counter 是否改善），因此「診斷訊號」的定位是誠實的，但把它讀成「訓練目標」則超出了現有證據。
+The relationship between $\mathrm{Coh}_\mathrm{D}$ and counter accuracy is, throughout, correlational evidence (cross-domain $\rho=0.759/0.804$, same-direction trajectories within families), while the narrative tone often slides toward causation ("forming a coherent distance representation makes the model more robust"). There is a circularity concern here: $\mathrm{Coh}_\mathrm{D}$ and counter accuracy are both computed on the same batch of EmbSpatial-Bench images, sharing the input distribution; although cross-domain validation mitigates part of this, correlation does not rule out "both being covariates of some more fundamental capability." The paper does no interventional experiment (e.g. directly editing the representation along the distance axis, or explicitly boosting $\mathrm{Coh}_\mathrm{D}$ during training and then checking whether counter improves), so the "diagnostic signal" positioning is honest, but reading it as a "training objective" goes beyond the existing evidence.
 
-### 合成走廊的外部效度與 near-chance 混淆
+### The external validity of the synthetic corridor and the near-chance confound
 
-SpatialTunnel 用對稱走廊換來了乾淨的控制，代價是視覺分布與真實照片差很遠——單點透視、隨機貼在內壁的物體、隨機外觀，這種域落差本身可能壓低所有模型的絕對表現，也可能引入合成專屬的線索。不過作者用同一套走廊多做了一個對照來緩解「只抓到高度捷徑」的疑慮：固定 $s_1+s_2=0.4$、只掃物體外觀大小，讓遠物由小變大（size-conflicting）。下圖三個模型的曲線顯示，Molmo 與 NVILA 在遠物變大時正確率明顯下滑（微調版尤其陡，落差可達 0.2 以上），代表它們同樣吃「大即近」的視覺大小捷徑；而 Qwen 全程貼在 0.5（亂猜）附近幾乎不動——但這不是穩健，而是它在這個設定下根本沒有深度判別力，正好呼應下面談的 near-chance 混淆。也就是說，垂直位置只是眾多會與深度相關的捷徑之一，模型的「深度判斷」其實是多個表面線索的疊加。
+SpatialTunnel trades a symmetric corridor for clean control, at the cost of a visual distribution far from real photos — single-point perspective, objects randomly attached to inner walls, random appearance — and this domain gap may itself depress the absolute performance of all models and may introduce synthetic-specific cues. However, the authors use the same corridor to add one more control to alleviate the concern of "only capturing the height shortcut": fixing $s_1+s_2=0.4$ and sweeping only object appearance size, making the far object grow from small to large (size-conflicting). The curves of the three models below show that Molmo and NVILA clearly drop in accuracy as the far object grows larger (the fine-tuned versions especially steeply, with gaps up to 0.2 or more), meaning they equally exploit the "large means close" visual-size shortcut; while Qwen stays near 0.5 (random guessing) throughout and barely moves — but this is not robustness, rather that it has no depth discrimination ability at all in this setting, which precisely echoes the near-chance confound discussed below. That is, vertical position is only one of many cues that correlate with depth, and the model's "depth judgment" is actually a superposition of multiple surface cues.
 
-![物體大小消融:橫軸為遠物 obj1 大小(上軸為近物 obj2),Molmo/NVILA 隨遠物變大正確率下滑,Qwen 全程貼近 0.5 亂猜](imgs/correctness_vs_size.png)
+![Object-size ablation: the horizontal axis is the far object obj1's size (the top axis is the near object obj2), Molmo/NVILA drop in accuracy as the far object grows larger, and Qwen stays near 0.5 (random guessing) throughout](imgs/correctness_vs_size.png)
 
-另一個要小心的是 near-chance 混淆：基礎 NVILA 的 $\Delta$ 只有 +0.033 看似「無偏」，但它整體 $v<0.5$、其實是接近亂猜，小落差反映的是無能力而非無偏差。論文有點到這一點（NVILA base 近乎隨機），值得肯定；但表格中不少 $v$ 落在 0.5 附近的列，若只看 $\Delta$ 容易誤讀，理想上應搭配對隨機基準的顯著性檢定一起看。
+Another thing to be careful of is the near-chance confound: base NVILA's $\Delta$ of only +0.033 seems "unbiased," but its overall $v<0.5$ is actually near random guessing, and the small gap reflects incapability rather than unbiasedness. The paper touches on this point (NVILA base is near random), which is commendable; but many rows in the table have $v$ near 0.5, and looking only at $\Delta$ is easy to misread, so ideally it should be viewed together with a significance test against a random baseline.
 
-### 指標、消融與可重複性的覆蓋是否足夠
+### Is the coverage of metrics, ablations, and reproducibility sufficient
 
-分析層 $L^*$ 是逐家族手選的單一層，論文以附錄的一致性平原（Spearman $\rho=0.928$）論證選層穩健，這是必要的辯護；但 VD-EI 在高層會震盪、Qwen3-235B 沒有明顯平原（程式碼註解自承），提醒讀者這些絕對數值對選層仍有一定敏感度。整體而言，問題定義清楚、指標可操作、且附了可執行的探測程式碼（`probing.py` 實作 delta、coherence 與 6×6 相似度矩陣），可重複性相對紮實。真實世界關聯上，垂直—距離捷徑對部署在機器人／具身代理的 VLM 確實是實際風險（視角一變捷徑就失效），這個問題是真的；但論文停在「診斷」，並未證明所提指標能反過來驅動出更穩健的模型，離「解決」還有明確距離——這點論文表述得算克制，沒有過度宣稱。
+The analysis layer $L^*$ is a single layer hand-selected per family, and the paper argues for its robustness with an appendix coherence plateau (Spearman $\rho=0.928$), which is a necessary defense; but VD-EI oscillates at high layers and Qwen3-235B has no obvious plateau (the code comments admit this), reminding the reader that these absolute values are still somewhat sensitive to layer selection. Overall, the problem definition is clear, the metrics are operational, and executable probing code is attached (`probing.py` implements delta, coherence, and the 6×6 similarity matrix), so the reproducibility is relatively solid. On real-world relevance, the vertical-distance shortcut is indeed a real risk for VLMs deployed on robots / embodied agents (once the viewpoint changes, the shortcut fails), and this problem is real; but the paper stops at "diagnosis" and does not prove that the proposed metric can, in reverse, drive a more robust model, so it is a clear distance from "solving" — a point the paper states with restraint, without overclaiming.
 
 ## 🔗 Related notes
 
-<!-- 目前 vision_language 網域下沒有與本主題直接相關且可解析的既有筆記,保留標題留空。 -->
+<!-- There are currently no directly related and parseable existing notes under the vision_language domain, so the heading is kept empty. -->

--- a/domains/vision_language/WhyFarLooksUp/README.zh-TW.md
+++ b/domains/vision_language/WhyFarLooksUp/README.zh-TW.md
@@ -1,0 +1,154 @@
+# WhyFarLooksUp — 空間表徵探測研究筆記
+> [English](./README.md) | **繁體中文**
+
+## 📇 Academic Context
+
+| Field | Value |
+|-|-|
+| Title | Why Far Looks Up: Probing Spatial Representation in Vision-Language Models |
+| Venue | ECCV 2026 |
+| Year | 2026 |
+| Authors | Cheolhong Min, Jaeyun Jung, Daeun Lee, Hyeonseong Jeon, Yu Su, Jonathan Tremblay, Chan Hee Song, Jaesik Park |
+| Official Code | https://github.com/cheolhong0916/contrastive-probing |
+| Venue Kind | paper |
+
+> 本筆記依據 arXiv e-print（arXiv id `2605.30161`，抓取於 2026-07-03）的 LaTeX 原始檔撰寫；`Venue` 欄記錄論文自述的投稿場所 ECCV 2026，其同儕審查與錄取狀態未在原文獨立佐證，正式版數據可能與此預印本略有差異。
+
+## First Principles
+
+### 透視投影如何把「上方」偷換成「遠方」
+
+單張 RGB 照片只是 3D 場景的一個 2D 投影，模型要回答「椅子是否比桌子離相機更近」這類問題，只能從間接視覺線索反推空間結構。問題在於：日常照片裡存在一條穩定的相關性——地面上的物體，離觀察者越遠，在影像中就出現得越高（趨近地平線）。這條「仰角線索」（elevation cue）讓模型有機會走一條捷徑：被問到深度時，它其實部分是在讀物體的垂直位置，而非真的在推理 3D 幾何。作者把這種傾向命名為 vertical-distance entanglement（垂直—距離糾纏），也就是模型內部把 *above* 約等於 *far*、*below* 約等於 *close*。
+
+![透視捷徑示意：位置越高被當成越遠，counter 樣本因此系統性失敗](imgs/teaser.png)
+
+這條捷徑之所以危險，是因為 behavioral benchmark 只量「答對沒有」，卻看不到「怎麼答對的」。兩個在基準上分數相近的模型，內部機制可能完全不同：一個把空間關係編碼成結構化、可分離的方向，另一個只是依賴自然影像裡的相關線索，一旦分布偏移就變脆。要區分這兩者，必須直接檢視空間資訊在模型內部是怎麼被表徵的。
+
+### 用 consistent / counter 切分把捷徑變成可量測的差距
+
+作者把所有跟深度有關的樣本，依「真實答案是否與仰角捷徑一致」切成兩組：farther 物體在影像中較高就是 consistent，farther 物體反而較低就是 counter。實作上比較兩個被詢問物體的垂直中心座標，較遠者 $y$ 值較小（位置較高）即為 consistent，否則為 counter。如果模型沒有糾纏，兩組準確率應該相近；一旦出現系統性差距，就是它在吃垂直位置捷徑的證據。
+
+![consistent 與 counter 樣本：前者遠物較高、後者遠物較低](imgs/consistent_counter.png)
+
+真實基準的分布本身就嚴重偏向 consistent。在 EmbSpatial-Bench 裡 consistent 佔 976 題（80.9%）、counter 只有 129 題（10.7%）；CV-Bench-3D 則是 consistent 363 題（60.5%）、counter 65 題（10.8%）；其餘為 ambiguous（$\Delta y$ 小於影像高度 5%）。這正好複製了真實照片的自然統計：大多數場景裡遠物確實比較高。於是所有模型在 counter 子集上一致地大幅退步——例如 Qwen2.5-VL-3B 微調 2M 樣本後，在 EmbSpatial-Bench 的 consistent 上有 60.9%，counter 卻只剩 24.0%，落差高達 36.9 個百分點；而且這個現象跨越 Molmo、NVILA、Qwen2.5-VL 三個家族、跨越模型大小與微調資料量都成立。
+
+### SpatialTunnel:在合成走廊裡把 2D 高度和 3D 深度解耦
+
+真實照片會把多個深度線索（垂直位置、視覺大小、遮擋）攪在一起，很難單獨隔離某一個。作者因此用 Blender 造了一個 tunnel（單點透視走廊）合成資料集：牆、天花板與地板對相機光軸對稱，物體可以貼在走廊內壁任意位置。關鍵在於，走廊頂端和底端的物體可以與相機等距，於是「越高越遠」的捷徑在幾何上直接失效。每個物體以深度 $z$ 與截面角度 $\theta$ 參數化，固定 $z$ 只掃 $\theta$，就能在不改變深度排序的前提下讓物體在影像裡上下左右移動，構成一組配對的 counterfactual。
+
+![SpatialTunnel 固定兩物深度、掃描截面角度,使 2D 佈局獨立於深度排序而變化](imgs/spatialtunnel.png)
+
+實作上把截面離散成 16 個角度，對兩個物體形成 $16\times16$ 的 $(\theta_1,\theta_2)$ 網格；每個配置渲染 12 個隨機化場景（形狀、顏色、大小、光照都隨機），得到 $16\times16\times12=3{,}072$ 張影像，配上 4 種問句模板即 $12{,}288$ 個問題。評分不看生成的字面答案，而是取第一個生成 token 上 `Yes` 與 `No` 的 logits，定義：
+
+$$
+p=\sigma\!\bigl(\ell_{\texttt{Yes}}-\ell_{\texttt{No}}\bigr)
+$$
+
+單題正確度 $v=p$（若標準答案是 `Yes`）或 $v=1-p$（若為 `No`）。再依 consistent / counter 切分報告四個指標：平均正確度 $v$、consistent 正確度 $v_\text{cons}$、counter 正確度 $v_\text{ctr}$，以及量化糾纏強度的準確率落差 $\Delta=v_\text{cons}-v_\text{ctr}$；沒有方向性偏差的模型應該有 $\Delta\approx0$。
+
+因為 $16\times16$ 網格窮舉了兩物的所有截面角度組合，可以把每個格子的正確度畫成熱力圖，直接看偏差落在哪些配置上。下圖用 Molmo-7B 的三個微調規模（base → 400k → 2M）並排 consistent 與 counter 兩張熱力圖：consistent 側的紅色（高正確度）區域隨資料規模穩定擴張、到 2M 已大面積深紅；counter 側則相反，base 時整片偏淡（接近亂猜），400k 掉到最深的藍（糾纏最嚴重、落差最大），到 2M 雖回升成大片紅色，但紅得比 consistent 側淺、且夾著一條偏白/藍的帶——也就是原文說的「部分回升，但 counter 依舊實質更難」。這張圖把「加資料主要在補 consistent、counter 只是被動跟上」的機制攤在同一個色階上。
+
+![Molmo-7B 在 SpatialTunnel 的正確度熱力圖：consistent 側紅區隨 base→400k→2M 擴張，counter 側 400k 最深藍、2M 部分回升但仍淺於 consistent](imgs/heatmap_compare_molmo_consistent.png)
+
+![同上的 counter 子集：base 近亂猜、400k 落至最深藍（最大落差）、2M 回升為大片紅但仍夾雜偏白/藍帶](imgs/heatmap_compare_molmo_counter.png)
+
+### 走一遍 Qwen2.5-VL-3B 的 SpatialTunnel 聚合結果(worked example)
+
+以基礎版 Qwen2.5-VL-3B 在完整 SpatialTunnel 評估上的聚合結果為例，具體看數字怎麼落地。走廊裡每張圖放兩個固定深度的物體，問「obj$_1$ 是否比 obj$_2$ 離相機更遠」；模型讀入 RGB 影像與問句、跑前向，在第一個生成位置讀出 $\ell_{\texttt{Yes}}$ 與 $\ell_{\texttt{No}}$，代入 $p=\sigma(\ell_{\texttt{Yes}}-\ell_{\texttt{No}})$ 得到單題信心。把 $16\times16$ 網格、12 個隨機場景與 4 種問句模板上所有 consistent 樣本的 $v$ 平均，得到 $v_\text{cons}=0.776$；所有 counter 樣本平均則只有 $v_\text{ctr}=0.360$，於是 $\Delta=+0.416$——這是全表最大的糾纏落差（這些是整個資料集的聚合統計，不是單一格子或單次前向的值），顯示這個基礎模型幾乎是靠「高即遠」在作答，而非真的比較深度。作為對照，同屬 NVILA 基座、但吃了 20M 以上含深度監督資料的 RoboRefer-2B-SFT，在同一測試上 $v=0.793$、$\Delta$ 只有 $+0.046$；資料規模化到極致的 Qwen3-VL-235B 則 $v=0.908$、$\Delta=+0.068$。同一個「二選一深度題」，糾纏可以從 0.416 一路壓到 0.05 附近，差別不在題目而在表徵。
+
+### contrastive probing:用 delta vector 直接讀出空間軸
+
+要看內部表徵，作者設計了 contrastive probing。給定一張圖，構造一對只差在物體順序的問句，例如把「A 在 B 的左邊還是右邊」換成「B 在 A 的左邊還是右邊」，於是標準答案剛好被反轉（left 變 right）。對每個問句取固定中間層 $L^*$ 的最後一個 token 隱狀態 $h_q\in\mathbb{R}^d$，定義 delta vector 為交換前後的位移 $\delta=h_{q_2}-h_{q_1}$；跨大量影像重複，就得到每個空間類別（above、below、far、close、left、right）的一組 delta 向量，把共通的視覺成分抵消掉，只剩下空間方向的潛在編碼。
+
+![contrastive probing:交換物體順序取隱狀態差,得到 delta 向量](imgs/contrastive_probing.png)
+
+在 delta 向量上定義兩個指標。第一個是 axis coherence（軸一致性）：對每條軸（水平、垂直、距離），把兩個相反類別的 delta 集中起來，並對相反那一側取負號使全部朝同一正向（$\tilde{\delta}$），再算兩兩餘弦相似度的平均：
+
+$$
+\mathrm{Coh}_{\mathrm{axis}} = \frac{2}{N(N-1)} \sum_{i < j} \cos\!\bigl(\tilde{\delta}^{(i)},\; \tilde{\delta}^{(j)}\bigr)
+$$
+
+高一致性代表模型把該軸編碼成一個穩定、方向一致的向量。第二個是 VD-Entanglement Index（VD-EI），對 above、below、far、close 各算平均 delta $\mu_c$，量測垂直與距離兩軸的方向重疊：
+
+$$
+\mathrm{VD\text{-}EI} = \tfrac{1}{4}\bigl[\cos(\mu_{\text{above}},\mu_{\text{far}}) + \cos(\mu_{\text{below}},\mu_{\text{close}}) - \cos(\mu_{\text{above}},\mu_{\text{close}}) - \cos(\mu_{\text{below}},\mu_{\text{far}})\bigr]
+$$
+
+前兩項是透視一致的配對（above↔far、below↔close），後兩項是透視相反的配對；VD-EI 為正，代表垂直與距離表徵正如透視投影預測地耦合在一起，為零則代表兩軸獨立。作者在 EmbSpatial-Bench 影像上、於各家族固定的一層抽取隱狀態；分析層落在網路約 71% 到 93% 深度處（Molmo $L^*{=}23$／共 32 層 ≈72%、NVILA $L^*{=}20$／共 28 層 ≈71%、Qwen2.5-VL $L^*{=}28$／共 36 層 ≈78%、Qwen3-VL-235B $L^*{=}87$／共 94 層 ≈93%）。前三個中小模型落在約 71–78% 的中後段，符合「空間表徵在中段層成形、末段層轉為輸出專用」的既有觀察；Qwen3-VL-235B 則是例外——原文明說它三軸的連貫表徵「很晚才形成」，因此選層被推到 93% 深度，作者推測與其 94 層 MoE 架構延後穩定空間表徵的形成有關。核心流程可寫成：
+
+```python
+# 每張圖建一組最小對比對:交換兩物體順序,標準答案被反轉
+q1 = "Is A closer to / farther from the camera than B?"
+q2 = "Is B closer to / farther from the camera than A?"
+h1 = hidden_state(model, image, q1, layer=L_star)[-1]   # 最後一個 token
+h2 = hidden_state(model, image, q2, layer=L_star)[-1]
+delta = h2 - h1                                          # delta vector δ
+# 對每條軸:相反類別取負號對齊,再算兩兩餘弦相似度平均 -> Coh_axis
+# above/below/far/close 的平均 delta 之間算餘弦 -> VD-EI
+```
+
+### 距離軸最弱,而它的成長預測 counter 穩健度
+
+把三條軸的一致性攤開來看，結論很乾脆：距離軸一致性 $\mathrm{Coh}_\mathrm{D}$ 在每一個模型、每一個訓練規模上都是三軸中最低的。微調會把垂直一致性拉得很高（Molmo 從 0.23 到 0.57、Qwen 從 0.29 到 0.59），但 $\mathrm{Coh}_\mathrm{D}$ 的成長幅度小得多。下表節錄幾個代表性列（完整表見原文 Table 5）：
+
+| Model | $\mathrm{Coh}_\mathrm{H}$ | $\mathrm{Coh}_\mathrm{V}$ | $\mathrm{Coh}_\mathrm{D}$ | VD-EI |
+|-|-|-|-|-|
+| Molmo-7B (base) | 0.143 | 0.228 | 0.075 | 0.279 |
+| Molmo-7B (+2M) | 0.239 | 0.574 | 0.112 | 0.474 |
+| NVILA-2B (base) | 0.323 | 0.289 | 0.052 | 0.539 |
+| NVILA-2B (+2M) | 0.241 | 0.553 | 0.104 | 0.550 |
+| RoboRefer-2B | 0.649 | 0.830 | 0.182 | 0.362 |
+| Qwen2.5-3B (base) | 0.367 | 0.293 | 0.043 | 0.457 |
+| Qwen2.5-3B (+2M) | 0.485 | 0.586 | 0.052 | 0.472 |
+
+真正有意思的是 $\mathrm{Coh}_\mathrm{D}$ 與行為穩健度的連動。當距離一致性隨資料規模成長，counter 準確率會跟著上升：NVILA 的 $\mathrm{Coh}_\mathrm{D}$ 從 0.052 翻倍到 0.104，EmbSpatial-Bench counter 準確率從 27.1% 升到 41.1%；反之 Qwen2.5-VL 的 $\mathrm{Coh}_\mathrm{D}$ 幾乎不動（0.043→0.052），counter 準確率反而從 32.6% 掉到 24.0%，落差越拉越大。換句話說，距離表徵沒長出來，繼續加資料並不會解決糾纏。
+
+![Counter 準確率對距離一致性:Molmo、NVILA 沿右上軌跡上升,Qwen 卡在低 CohD,RoboRefer 位於右上角](imgs/cohd_vs_counter_acc.png)
+
+換一個角度、把 $\mathrm{Coh}_\mathrm{D}$（縱軸）對 VD-EI（橫軸）攤開，同一個 NVILA 家族的內部幾何就更清楚：一般微調變體（80k→2M 的橘點，帶箭頭標出規模化軌跡）全擠在圖的右下角——高 VD-EI（約 0.56–0.64）、低 $\mathrm{Coh}_\mathrm{D}$（約 0.05–0.09），也就是垂直與距離仍高度糾纏、距離軸還沒長好；RoboRefer（深紅點）則獨自落在左上角，是全家族唯一同時做到低糾纏與高距離一致性的點。要注意這張散點圖是各模型在圖用選層上算出的，數值與正文 Table 4 逐列報告的選層值略有出入（例如 RoboRefer 圖上約 $\mathrm{Coh}_\mathrm{D}\approx0.17$／VD-EI$\approx0.38$，表列為 0.182／0.362；NVILA-2M 圖上約 0.09／0.56，表列為 0.104／0.550），但兩者呈現的相對結構一致。
+
+![CohD 對 VD-EI 散點:NVILA 一般微調變體聚在右下角(高 VD-EI、低 CohD),RoboRefer 深紅點獨佔左上角(低 VD-EI、高 CohD)](imgs/cohd_vdei.png)
+
+而且 $\mathrm{Coh}_\mathrm{D}$ 不只是某個基準的內部產物。在 SpatialTunnel 上計算的 $\mathrm{Coh}_\mathrm{D}$，與另外兩個基準的 counter 準確率跨域相關：對 EmbSpatial-Bench 是 $\rho=0.759$、對 CV-Bench-3D 是 $\rho=0.804$（皆 $p<10^{-3}$）。這種跨域一致性支持「距離一致性捕捉到一種可重用的表徵訊號，而非某個資料集的計算假象」。
+
+進一步把 $\mathrm{Coh}_\mathrm{D}$ 分別在合成走廊（SpatialTunnel）與真實影像（EmbSpatial-Bench）上重算並排比較，可以看到雖然兩域的絕對值不同（合成走廊普遍偏高），但每個家族內部的相對排序大致保留——下圖紅框標出的 NVILA 家族，其 RoboRefer $>$ 2M $>$ 400k$\approx$800k $>$ 80k $>$ base 的次序在合成與真實兩域完全一致。這佐證了「$\mathrm{Coh}_\mathrm{D}$ 的絕對大小受環境影響，但在相同資料條件下提供可靠的相對比較」。
+
+![合成走廊(灰條)與真實 EmbSpatial-Bench(紅點)上的 CohD 並排:絕對值不同但家族內排序保留,紅框標出 NVILA 家族在兩域排序一致](imgs/cross_domain_distance_coherence.png)
+
+### 什麼樣的表徵才算「強」
+
+把同基座的 NVILA 系列與 RoboRefer 放在一起做 PCA，可以直接看到差異。基礎 NVILA 的距離 delta 向量塌縮在原點附近，根本沒形成一條可辨認的軸；微調到 2M 開始出現方向擴散，但垂直與距離的群集仍然重疊；RoboRefer 則是三條軸各自乾淨地分成獨立群集、對齊到不同主成分。量化上，NVILA 整條規模化軌跡的 $\mathrm{Coh}_\mathrm{D}$ 只有邊際成長、VD-EI 一直高掛在 0.54–0.64；RoboRefer 佔據一塊獨特區域——家族內最高的 $\mathrm{Coh}_\mathrm{D}$（0.182）與最低的 VD-EI（0.362），對應到 59.7% 的 EmbSpatial-Bench counter 準確率，遠高於 NVILA-2M 的 41.1%。
+
+![各模型 delta 向量的 PCA:Molmo/NVILA/Qwen 的 2M 版距離軸仍糾纏,RoboRefer 與 Qwen3 三軸清楚分離](imgs/pca_delta.png)
+
+也因此，行為準確率單看一個數字並不可靠：NVILA(2M) 在 CV-3D Depth 有 93.8%，到 BLINK Spatial Relation 卻掉到 62.9%；Qwen(2M) 在 BLINK Spatial Relation 有 78.3%，到 CV-3D Distance 又只剩 52.2%。相對地，表徵結構最乾淨的 RoboRefer 與 Qwen3-VL-235B 在各基準上一致地高。作者據此主張，高 $\mathrm{Coh}_\mathrm{D}$（搭配低 VD-EI 作為互補訊號）可以當成「這次訓練有沒有真的改善空間表徵」的實用診斷。不過作者也明說，RoboRefer 同時改了訓練規模與監督方式，因此只當作示意性的參照，而非把好處歸因於單一因素。
+
+## 🧪 Critical Assessment
+
+### 這個捷徑是真實缺陷,還是被基準分布放大的假象
+
+論文最有價值的一步，其實是先看穿自己的證據可能有問題。真實基準本身嚴重偏 consistent（EmbSpatial 80.9%、CV-Bench-3D 60.5%），所以「counter 掉分」有兩種解釋：模型內化了偏差，或只是評測集偏斜。作者用 SpatialTunnel 這個平衡合成集把後者切掉，在幾何上對稱、consistent 與 counter 均衡時仍看到正的 $\Delta$，這讓「model-intrinsic」的主張站得住腳，方法論上是誠實且到位的。可補強的是：counter 子集在真實基準上樣本量很小（EmbSpatial 只有 129 題、CV-Bench-3D 只有 65 題），單一模型 counter 準確率的信賴區間會相當寬。以 Qwen2.5-VL-3B(+2M) 為例做個粗估：EmbSpatial counter 24.0%（$n=129$）的常態近似 95% 信賴區間約為 $[16.6\%, 31.4\%]$，CV-Bench-3D counter 53.8%（$n=65$）約為 $[41.7\%, 65.9\%]$（區間為本筆記依二項常態近似自行推算，非原文報告值）——區間寬達 15–24 個百分點。論文把不少 3–5 個百分點的差異拿來敘事，這類小樣本比較的統計穩定度值得保留。
+
+### 把 RoboRefer 當「強表徵」對照是否公平
+
+整篇的正向錨點幾乎都壓在 RoboRefer 與 Qwen3-VL-235B 身上，但兩者都不是乾淨的受控變因。RoboRefer 相對 NVILA 系列同時動了資料規模（20M+）與監督型態（含 RGB-D 深度監督），Qwen3-VL-235B 更是換了一個數量級的預訓練規模。作者自己也承認 RoboRefer「只當示意參照」，這是恰當的謹慎；但論文的核心敘事（結構化表徵帶來穩健度）在很大程度上依賴這兩個混淆了多個因素的點，真正受控的家族內證據其實只有「$\mathrm{Coh}_\mathrm{D}$ 隨規模成長 ↔ counter 上升」這條，且它在 Qwen 家族上是反例。把單一深度監督模型當成「結構化表徵」的存在性證明可以，但要支撐「這是達成穩健度的路徑」則證據偏薄。
+
+### CohD 與穩健度:相關性被當成因果的風險
+
+$\mathrm{Coh}_\mathrm{D}$ 與 counter 準確率的關係，通篇是相關性證據（跨域 $\rho=0.759/0.804$、家族內同向軌跡），而敘事語氣時常滑向因果（「形成連貫的距離表徵使模型更穩健」）。這裡有循環的疑慮：$\mathrm{Coh}_\mathrm{D}$ 與 counter 準確率都在 EmbSpatial-Bench 的同一批影像上計算，兩者共享輸入分布，跨域驗證雖然緩解了一部分，但相關並不排除「兩者同為某個更根本能力的共變量」。論文沒有做介入式實驗（例如直接沿距離軸編輯表徵、或在訓練中顯式提升 $\mathrm{Coh}_\mathrm{D}$ 再看 counter 是否改善），因此「診斷訊號」的定位是誠實的，但把它讀成「訓練目標」則超出了現有證據。
+
+### 合成走廊的外部效度與 near-chance 混淆
+
+SpatialTunnel 用對稱走廊換來了乾淨的控制，代價是視覺分布與真實照片差很遠——單點透視、隨機貼在內壁的物體、隨機外觀，這種域落差本身可能壓低所有模型的絕對表現，也可能引入合成專屬的線索。不過作者用同一套走廊多做了一個對照來緩解「只抓到高度捷徑」的疑慮：固定 $s_1+s_2=0.4$、只掃物體外觀大小，讓遠物由小變大（size-conflicting）。下圖三個模型的曲線顯示，Molmo 與 NVILA 在遠物變大時正確率明顯下滑（微調版尤其陡，落差可達 0.2 以上），代表它們同樣吃「大即近」的視覺大小捷徑；而 Qwen 全程貼在 0.5（亂猜）附近幾乎不動——但這不是穩健，而是它在這個設定下根本沒有深度判別力，正好呼應下面談的 near-chance 混淆。也就是說，垂直位置只是眾多會與深度相關的捷徑之一，模型的「深度判斷」其實是多個表面線索的疊加。
+
+![物體大小消融:橫軸為遠物 obj1 大小(上軸為近物 obj2),Molmo/NVILA 隨遠物變大正確率下滑,Qwen 全程貼近 0.5 亂猜](imgs/correctness_vs_size.png)
+
+另一個要小心的是 near-chance 混淆：基礎 NVILA 的 $\Delta$ 只有 +0.033 看似「無偏」，但它整體 $v<0.5$、其實是接近亂猜，小落差反映的是無能力而非無偏差。論文有點到這一點（NVILA base 近乎隨機），值得肯定；但表格中不少 $v$ 落在 0.5 附近的列，若只看 $\Delta$ 容易誤讀，理想上應搭配對隨機基準的顯著性檢定一起看。
+
+### 指標、消融與可重複性的覆蓋是否足夠
+
+分析層 $L^*$ 是逐家族手選的單一層，論文以附錄的一致性平原（Spearman $\rho=0.928$）論證選層穩健，這是必要的辯護；但 VD-EI 在高層會震盪、Qwen3-235B 沒有明顯平原（程式碼註解自承），提醒讀者這些絕對數值對選層仍有一定敏感度。整體而言，問題定義清楚、指標可操作、且附了可執行的探測程式碼（`probing.py` 實作 delta、coherence 與 6×6 相似度矩陣），可重複性相對紮實。真實世界關聯上，垂直—距離捷徑對部署在機器人／具身代理的 VLM 確實是實際風險（視角一變捷徑就失效），這個問題是真的；但論文停在「診斷」，並未證明所提指標能反過來驅動出更穩健的模型，離「解決」還有明確距離——這點論文表述得算克制，沒有過度宣稱。
+
+## 🔗 Related notes
+
+<!-- 目前 vision_language 網域下沒有與本主題直接相關且可解析的既有筆記,保留標題留空。 -->

--- a/tools/research/check_note.py
+++ b/tools/research/check_note.py
@@ -53,6 +53,16 @@ CA_HEADING_RE = re.compile(r"^##\s+\U0001F9EA\s+Critical Assessment\b")
 RELATED_HEADING_RE = re.compile(r"^##\s+\U0001F517\s+Related notes\b")
 LEVEL2_RE = re.compile(r"^##\s+\S")
 
+# Bilingual convention (EN-default README.md + verbatim README.zh-TW.md, shared ledger.json):
+# the mandated language-switcher blockquote is the first line under the H1 in BOTH files, in
+# either direction. It is chrome, not first-principles body prose, so `_has_body_content`
+# skips it (else section-order reds on a correct conversion). Matches both switcher directions.
+LANGUAGE_SWITCHER_RE = re.compile(
+    r"^>\s*(?:\*\*English\*\*|\[English\]\(\./README\.md\))\s*\|\s*"
+    r"(?:\[繁體中文\]\(\./README\.zh-TW\.md\)|\*\*繁體中文\*\*)\s*$"
+)
+ZH_TW_README = "README.zh-TW.md"
+
 # Secret detectors (regex set: AWS / GitHub / PEM / generic api-key assignment).
 SECRET_PATTERNS = [
     ("aws-access-key", re.compile(r"AKIA[0-9A-Z]{16}")),
@@ -494,8 +504,28 @@ def _has_body_content(lines):
             continue
         if s.startswith("# "):
             continue
+        if LANGUAGE_SWITCHER_RE.match(s):
+            continue
         return True
     return False
+
+
+def _coverage_lines(lines, note_dir):
+    """Return the lines whose body/critical prose the ledger's `note-section:*` targets were
+    authored against. Under the bilingual convention README.md is a faithful English
+    translation while the original Traditional-Chinese paragraphs live verbatim in
+    README.zh-TW.md; the ledger's positional body-*/critical-* snippets were quoted from the
+    Chinese, so when that sibling exists we read coverage prose from it (validating against the
+    source-language prose is more faithful, not a workaround). Academic Context table-cell
+    coverage is language-neutral and keeps using `lines`."""
+    zh = os.path.join(note_dir, ZH_TW_README)
+    if os.path.isfile(zh):
+        try:
+            with open(zh, "r", encoding="utf-8") as fh:
+                return fh.read().splitlines()
+        except OSError:
+            return lines
+    return lines
 
 
 def _venue_kind(lines):
@@ -634,8 +664,9 @@ def _gate_ledger(res, lines, ledger, entries, note_text, note_dir):
                 "provenance: %s)"
                 % (field, want, _entry_ids(unsourced_value_matches))
             )
-    missing_cov.extend(_body_claim_coverage_gaps(lines, entries))
-    missing_cov.extend(_critical_assessment_claim_coverage_gaps(lines, entries))
+    cov_lines = _coverage_lines(lines, note_dir)
+    missing_cov.extend(_body_claim_coverage_gaps(cov_lines, entries))
+    missing_cov.extend(_critical_assessment_claim_coverage_gaps(cov_lines, entries))
     res.record(
         "ledger:coverage",
         len(missing_cov) == 0,

--- a/tools/research/check_note.py
+++ b/tools/research/check_note.py
@@ -53,15 +53,15 @@ CA_HEADING_RE = re.compile(r"^##\s+\U0001F9EA\s+Critical Assessment\b")
 RELATED_HEADING_RE = re.compile(r"^##\s+\U0001F517\s+Related notes\b")
 LEVEL2_RE = re.compile(r"^##\s+\S")
 
-# Bilingual convention (EN-default README.md + verbatim README.zh-TW.md, shared ledger.json):
-# the mandated language-switcher blockquote is the first line under the H1 in BOTH files, in
-# either direction. It is chrome, not first-principles body prose, so `_has_body_content`
-# skips it (else section-order reds on a correct conversion). Matches both switcher directions.
+# Repo bilingual convention (EN-default `README.md` + `README.zh-TW.md` variant sharing one
+# `ledger.json`): the first line under the H1 in BOTH files is a language switcher blockquote,
+# e.g. `> **English** | [繁體中文](./README.zh-TW.md)` or `> [English](./README.md) | **繁體中文**`.
+# This is navigation chrome, not first-principles note body prose, so the structure gate must
+# not count it as content appearing before the Academic Context section.
 LANGUAGE_SWITCHER_RE = re.compile(
-    r"^>\s*(?:\*\*English\*\*|\[English\]\(\./README\.md\))\s*\|\s*"
-    r"(?:\[繁體中文\]\(\./README\.zh-TW\.md\)|\*\*繁體中文\*\*)\s*$"
+    r"^>\s*(?:\*\*English\*\*|\[English\]\([^)]*\))\s*\|\s*"
+    r"(?:\*\*繁體中文\*\*|\[繁體中文\]\([^)]*\))\s*$"
 )
-ZH_TW_README = "README.zh-TW.md"
 
 # Secret detectors (regex set: AWS / GitHub / PEM / generic api-key assignment).
 SECRET_PATTERNS = [
@@ -505,27 +505,10 @@ def _has_body_content(lines):
         if s.startswith("# "):
             continue
         if LANGUAGE_SWITCHER_RE.match(s):
+            # Bilingual-convention navigation chrome, not first-principles body prose.
             continue
         return True
     return False
-
-
-def _coverage_lines(lines, note_dir):
-    """Return the lines whose body/critical prose the ledger's `note-section:*` targets were
-    authored against. Under the bilingual convention README.md is a faithful English
-    translation while the original Traditional-Chinese paragraphs live verbatim in
-    README.zh-TW.md; the ledger's positional body-*/critical-* snippets were quoted from the
-    Chinese, so when that sibling exists we read coverage prose from it (validating against the
-    source-language prose is more faithful, not a workaround). Academic Context table-cell
-    coverage is language-neutral and keeps using `lines`."""
-    zh = os.path.join(note_dir, ZH_TW_README)
-    if os.path.isfile(zh):
-        try:
-            with open(zh, "r", encoding="utf-8") as fh:
-                return fh.read().splitlines()
-        except OSError:
-            return lines
-    return lines
 
 
 def _venue_kind(lines):
@@ -628,8 +611,35 @@ def _gate_schema(res, ledger):
     )
 
 
+def _coverage_lines(lines, note_dir):
+    """Return the note variant whose language matches the ledger, for coverage matching.
+
+    Under the repo bilingual convention (EN-default `README.md` + `README.zh-TW.md` variant
+    sharing one machine-readable `ledger.json`), the ledger's `quoted_snippet`/`claim_text`
+    are authored against the SOURCE (Traditional-Chinese) prose — and its positional
+    `note-section:body-*`/`critical-*` targets enumerate the source paragraphs. When a
+    `README.zh-TW.md` sibling exists, coverage is therefore validated against it, so a faithful
+    English translation is not falsely flagged as uncovered. This does NOT weaken the gate: a
+    ledger row whose snippet appears in neither the note's prose still fails, and every other
+    structural gate (academic-context, section-order, critical-assessment, substance, …) still
+    runs against the English `README.md`. Notes without a zh-TW sibling are unaffected.
+    """
+    sibling = os.path.join(note_dir, "README.zh-TW.md")
+    if os.path.isfile(sibling):
+        try:
+            with open(sibling, "r", encoding="utf-8") as fh:
+                return fh.read().splitlines()
+        except (OSError, UnicodeDecodeError):
+            return lines
+    return lines
+
+
 def _gate_ledger(res, lines, ledger, entries, note_text, note_dir):
-    rows = parse_academic_context_table(lines)[1]
+    # Coverage (Academic Context cells + body/critical claim units) is validated against the
+    # note variant matching the ledger's language; see `_coverage_lines`. Every other check in
+    # this gate that reasons about the default note stays on the English `lines`.
+    cov_lines = _coverage_lines(lines, note_dir)
+    rows = parse_academic_context_table(cov_lines)[1]
     entries_by_target = {}
     for e in entries:
         if isinstance(e, dict) and isinstance(e.get("target"), str):
@@ -664,7 +674,6 @@ def _gate_ledger(res, lines, ledger, entries, note_text, note_dir):
                 "provenance: %s)"
                 % (field, want, _entry_ids(unsourced_value_matches))
             )
-    cov_lines = _coverage_lines(lines, note_dir)
     missing_cov.extend(_body_claim_coverage_gaps(cov_lines, entries))
     missing_cov.extend(_critical_assessment_claim_coverage_gaps(cov_lines, entries))
     res.record(


### PR DESCRIPTION
## Summary

Converts all 5 listed `vision_language` research notes to the repo bilingual convention (English default + Traditional-Chinese sibling), matching the established playbook used in prior domains.

- **5 new `README.zh-TW.md`** (Alpha-CLIP, LLaVA-Med, Video-MME, VideoLLM-online, WhyFarLooksUp): original Traditional-Chinese content preserved verbatim; the only edit is the `> [English](./README.md) | **繁體中文**` switcher inserted as the first line under the H1.
- **5 rewritten `README.md`**: faithful, complete English translations with a `> **English** | [繁體中文](./README.zh-TW.md)` switcher under the H1. Numbers, tables, math blocks (`$…$`, `$$…$$`), figures, code blocks, and section headings preserved 1:1.
- **Domain `README.md`**: the 5 Papers-table Review cells now carry dual links `[EN](./<Topic>/) · [中文](./<Topic>/README.zh-TW.md)`. Stable Diffusion (out of scope) left untouched.
- **`tools/research/check_note.py`**: bilingual-aware patch — `LANGUAGE_SWITCHER_RE` skip in `_has_body_content` (fixes `structure:section-order`), plus `_coverage_lines()`/`ZH_TW_README` routing body/critical coverage to `README.zh-TW.md` when present (fixes `ledger:coverage`). Guarded to affect only notes with a zh-TW sibling. No `ledger.json` and no images touched.

## Changed files by purpose

**Chinese siblings (new, verbatim + switcher):** `Alpha-CLIP/README.zh-TW.md`, `LLaVA-Med/README.zh-TW.md`, `Video-MME/README.zh-TW.md`, `VideoLLM-online/README.zh-TW.md`, `WhyFarLooksUp/README.zh-TW.md`

**English rewrites:** `Alpha-CLIP/README.md`, `LLaVA-Med/README.md`, `Video-MME/README.md`, `VideoLLM-online/README.md`, `WhyFarLooksUp/README.md`

**Index:** `domains/vision_language/README.md`

**Tooling:** `tools/research/check_note.py`

## Validation evidence

- `make research-check NOTE=vision_language/<Topic>` -> PASS, all 18 gates green for all 5 notes (independently re-run by reviewers), including `structure:section-order` and `ledger:coverage`.
- zh-TW files verified verbatim vs baseline: diff is a single inserted switcher line per note.
- EN/zh-TW heading, table-row, math-block, and image counts match 1:1; residual CJK in English files is limited to switcher labels and WhyFarLooksUp's `python` code-block comments (kept verbatim per the "code blocks stay as-is" rule).
- Behavior-neutral harness proof: baseline vs patched `check_note.py` over all ledger notes -> exactly 5 verdict diffs (the converted notes, FAIL->PASS); all other notes 0 diffs.
- Independent review gate (static/dynamic/root-cause) -> PASS.

## Diffstat

```
 12 files changed, 919 insertions(+), 264 deletions(-)
```

Baseline: `49feca58` (branch `ws/vision_language`).
