### PR TITLE
docs(mlops): coding-agent token-efficiency survey note

### DIFF
--- a/domains/mlops/CodingAgentTokenEfficiency/README.md
+++ b/domains/mlops/CodingAgentTokenEfficiency/README.md
@@ -1,0 +1,224 @@
+# Token-Saving Tools & Papers for Coding Agents — Mechanisms, Costs, User Evidence
+
+> **English** | [繁體中文](./README.zh-TW.md)
+
+## 📇 Academic Context
+
+| Field | Value |
+|-|-|
+| Title | Projects and papers claiming to save 20~40% tokens for coding agents like Claude Code / Codex: mechanisms, costs, and user evidence |
+| Venue Kind | survey (a market audit across 11 representative projects + 30-odd peripheral tools/papers) |
+| Year | 2026 |
+| Survey date | 2026-07-16 (all web sources retrieved on the same date unless noted) |
+| Method | read-only audit: citations only from pages actually opened and read (official blogs / arXiv full text / GitHub API / HN Algolia / Reddit archive API / static clone); every load-bearing claim ran at least one refutation search; no downloaded code was executed |
+
+> This note is not a single-paper summary but a market-audit survey. The audit target is the *claim itself* that a tool "saves 20~40% tokens for coding agents." **Every vendor number is treated first as an unverified seed**; whenever it conflicts with a primary source, the primary source wins. Each claim is interrogated with "what is being measured, under what workload, and against which baseline?"
+
+---
+
+## One-Sentence Conclusion
+
+> **The "20~40% saving" band is itself credible — but it is the residual left after each vendor's 60~95% marketing number is discounted by independent measurement, not any vendor's original claim.** Risk varies enormously across mechanisms: output-side trimming and lazy loading are nearly lossless; token-level pruning (LLMLingua style) is a disaster for coding; retrieval-instead-of-whole-file is the right direction but implementation quality often eats the theoretical gains.
+
+One comparison says it best: the only **neutral, same-task, same-machine** cross-test (ComputingForGeeks, baseline 284,473 tokens) measured a batch of tools that self-claim 60~95% savings at **0~43%**:
+
+| Tool | Self-claimed | Neutral cross-test |
+|-|-|-|
+| token-savior | −80% | **43%** |
+| caveman | 65% | **38% / 37%** |
+| ooples token-optimizer-mcp | 95%+ | **23%** |
+| RTK | 60~90% | **0%** (no saving at all when output is clean) |
+| code-review-graph | — | **5%** (on small repos it is 0.7x — actually more expensive) |
+
+Users' impression of "20~40%" lines up with independent measurement — not with the vendor headlines (60~95%).
+
+---
+
+## The Three Investigation Questions
+
+The three questions this audit answers:
+
+- **Q1 — Mechanism**: through what mechanism does each project reduce tokens? Every mechanism must come with a **concrete example** (an actual file/function in the repo, or an actual algorithm/table in the paper), not just a restatement of marketing language.
+- **Q2 — Cost**: beyond token reduction, do these mechanisms affect the LLM's **capability and correctness**? What evaluation evidence does each project provide itself? Is there any independent third-party evaluation? Where is the evidence strong, and where are the gaps?
+- **Q3 — User evidence**: do user reports, GitHub issues, and community discussion of problems/bugs point at the Q2 suspicion (dropping key context, editing the wrong file, answering the wrong question, the agent getting lost)?
+
+### Quick-Reference Conclusions
+
+| Question | Conclusion |
+|-|-|
+| **Q1 Mechanism** | Five mechanism classes: ① token-level prompt compression ② semantic/symbol retrieval replacing whole-file reads ③ context middleware / long-term memory ④ output-side diff-edit ⑤ model routing / caching proxy. See "Mechanism Taxonomy". |
+| **Q2 Cost** | Huge variation, and tierable (see risk table below). Key finding: token-level perplexity (a measure of how "surprised" the model is by a span of text) pruning breaks coding identifiers/values/syntax (post-compression AST (Abstract Syntax Tree) validity is only **0.29%**); whereas **line-level task-aware pruning** (SWE-Pruner) achieves −23~38% tokens on the full SWE-bench Verified while success rate **rises** by 1.2~1.4 percentage points (pts). |
+| **Q3 User evidence** | Heavily corroborates the Q2 suspicion: Serena "hits context limits faster than without it" + silently corrupts code; claude-context index desync "never able to search"; mem0 stores mutually contradictory memories; Claude Code's own /compact is the single largest source of "amnesia after compression" complaints. |
+
+---
+
+## Core: Tiered by Risk (Q2: the cost to capability and correctness)
+
+Sorting every mechanism by "does saving tokens hurt capability" is this survey's most useful output, and it is the overall answer to Q2:
+
+| Risk | Mechanism | Why |
+|-|-|-|
+| 🟢 **Lowest** | diff / targeted edits (output-side), noisy tool-output compression (RTK style), tool-definition lazy loading, prompt caching | Near-lossless by mechanism; Anthropic's own token-efficient tool use (avg 14%) is the only case that is "deployed at scale with zero regression reports". |
+| 🟡 **Medium** | semantic/symbol retrieval replacing whole-file feeding (Serena, claude-context); **line-level task-aware context pruning (SWE-Pruner)** | Independent positive evidence for the direction (Cursor A/B (A/B test): +12.5% accuracy), but the implementation layer (index desync, MCP (Model Context Protocol) fixed overhead, symbol-edit corruption) often eats the gains; SWE-Pruner has the strongest evidence of all, but single-team, zero replication, Python-only. |
+| 🔴 **High** | **token-level / perplexity pruning (LLMLingua style) for coding**; classifier-based model routing for agentic coding | Multiple independent sources consistently show corruption of identifiers/values/AST; routing collapses on OOD (out-of-distribution, i.e. test scenarios differ from training data) coding + protocol incompatibility scraps entire tool-use turns. |
+| ⚫ **Cannot assess** | zero-methodology behavior-injection frameworks (SuperClaude style), zero-methodology "95%+" MCPs | No benchmark, no methodology; there is even reverse evidence (the framework itself eats 40k+ tokens of context). |
+
+> Note: the 🔴 verdict is **limited to token-level pruning**, and does not extend to line-level task-aware pruning — they are different mechanism families; see "Mechanism Taxonomy ①" and "Deep Dive: SWE-Pruner".
+
+### WRAPUP: Per-Tool Master Table
+
+The master table at a glance. **Mechanism**: A=token-level compression, B=retrieval-instead-of-whole-file, C=context middleware/memory, D=output-side diff, E=routing/caching. **Evidence strength** (same color scheme as capability risk, 🟢=good, 🔴=bad): 🟢 has a public benchmark that is (in principle) reproducible; 🟡 only vendor self-test or too small a sample; 🔴 no methodology or explicitly refuses evaluation (incl. LLM-self-grading only). **Capability risk** follows the tiers above: 🟢 lowest, 🟡 medium, 🔴 high, ⚫ cannot assess (zero methodology — can't even judge whether it hurts capability).
+
+| Project | Mechanism | Claimed saving (measurement basis) | Evidence strength | Capability risk | Negative user signal |
+|-|-|-|-|-|-|
+| SWE-Pruner | A (line-level) | 23~54% token (agent total tokens, success rate rises) | 🟢 single-team, zero replication | 🟡 | none found (but small deployment base) |
+| Aider (repo-map + diff) | B+D | claims no % (repo-map is an overhead) | 🟢 most honest of all | 🟢 diff (strong models) / 🟡 repo-map | yes: #752 budget overshoot 16x, SEARCH-REPLACE failure cluster |
+| claude-context | B | ~40% (30-question localization) | 🟡 n=30, weak model | 🟡 | yes: index desync #145/#226/#232 |
+| LLMLingua family | A (token-level) | up to 20x (input tokens, CoT tasks) | 🟡 official narrow / punctured on coding by independent evidence | 🔴 (coding) | yes: #89 error rate +18pts, #136 collapses to 0.02 |
+| mem0 | C | >90% (vs replaying full history) | 🟡 highly disputed | 🟡 | yes: #5867 contradictory memories |
+| Anthropic official features | C/D/E | 84% / 14~70% / 85% / 98.7% (internal) | 🟡 internal-only, mechanism transparent | 🟢 | few; only /compact draws many "amnesia" complaints |
+| RouteLLM | E | 85% cost saving + retains 95% (no coding) | 🟡 in-domain / collapses OOD | 🔴 (agentic) | strong academic refutation, no notable repo complaints |
+| Serena | B | no number (community rumor of 70%, no source found) | 🔴 explicitly refuses testing, LLM self-grades | 🟡 | yes: Reddit "actually uses more", #1529 silent code corruption |
+| SuperClaude | C | 70%→30-50% (zero methodology) | 🔴 | ⚫ | yes: #286 framework itself eats 43.8k context |
+| claude-code-router | E | no % claim of its own | 🔴 no evaluation | 🔴 protocol incompatibility | yes: #1378 tool use fully broken |
+| token-savior | B/C/D | −80% self-claimed → neutral 43% | 🔴 self-made tsbench | 🟡 no rigorous capability test | — |
+| caveman | D (forces telegraphic output) | 65% self-claimed → neutral 38% | 🔴 self-test | 🟢 neutral test "same answers"; but terse workloads may net-increase | — |
+| ooples token-optimizer-mcp | B/D | 95%+ self-claimed → neutral 23% | 🔴 zero methodology | 🟡 untested | — |
+| RTK | D (compresses noisy output) | 60~90% self-claimed → neutral 0% | 🔴 self-test | 🟢 only compresses noise, low risk | — |
+| code-review-graph | B (graph retrieval) | neutral 5% (small repos 0.7x — more expensive) | 🔴 | 🟡 untested | — |
+| Others (claude-mem, Headroom, etc.) | C/D | 10x, ~50% (self-claimed) | 🔴 self-test | 🟡 | yes: claude-mem #618 token bloat |
+
+---
+
+## Mechanism Taxonomy (Q1: mechanism + concrete example)
+
+### ① Token-level prompt compression — the LLMLingua family
+
+- **Representative**: LLMLingua / LongLLMLingua / LLMLingua-2 (Microsoft, arXiv 2310.05736 / 2310.06839 / 2403.12968)
+- **Mechanism**: a small language model computes each token's perplexity and deletes "low-information" tokens outright.
+- **Concrete example**: the official README compresses a 2,365-token GSM8K CoT (chain-of-thought, a prompt asking the model to reason step by step) prompt down to 211 tokens (11.2x). But the official sample output is already corrupted: *"He reanged five of boxes into packages of sixlters each..."* — the marketing page itself displays the mechanism's cost.
+- **The official pipeline even bundles a "repair" step**: LongLLMLingua has a subsequence recovery step that restores corrupted entities (e.g. "209" back to "2009") after the fact — effectively an official admission that compression breaks the surface form.
+- **Claim basis**: "up to 20x compression with minimal performance loss" measures **input prompt tokens**, with a workload of GSM8K/BBH CoT + GPT-3.5-0613.
+
+### ② Semantic / symbol retrieval replacing whole-file reads
+
+Replace "stuffing the whole file into context" with precise retrieval.
+
+- **Serena MCP** (26.5k★): symbol-level retrieval via LSP (Language Server Protocol, the standard interface an IDE uses to get symbols/definitions/references); tools use a symbol name path (`MyClass/my_method`) instead of reading the whole file.
+  - Code: `FindSymbolTool` (`src/serena/tools/symbol_tools.py:132`, whose `include_body` param is annotated "Use judiciously"), `GetSymbolsOverviewTool` (`:36`), `ReplaceSymbolBodyTool` (`:571`).
+  - **The real example from its own eval**: `get_symbols_overview` returns ~2.5KB JSON per call vs Grep's ~3KB; the official phrasing for the saving is *"saves ~1 call and some context window tokens per navigation"* — far smaller than the community-rumored "70% saving" (that 70% has no traceable source).
+- **claude-context** (Zilliz, 12.1k★): AST-aware chunking → embedding → Milvus vector DB → hybrid retrieval.
+  - **The only "in principle reproducible" vendor measurement** (repo `evaluation/README.md`): 30 SWE-bench Verified retrieval subtasks, GPT-4o-mini, tokens 73,373 → 44,449 (**−39.4%**), F1 (harmonic mean of precision and recall; higher = better at finding the right file) 0.40 vs 0.40 unchanged. This is the entire experimental basis for the marketing line "Cut Token Waste by 40%".
+  - Weaknesses: n=30, restricted to 2-file changes, uses the weak model that benefits most from retrieval, tests only file localization (F1=0.40 means both groups have a >50% chance of picking the wrong file).
+- **Aider repo-map** (the most honest of all): tree-sitter extracts symbols + PageRank ranking, **binary-searched into a fixed token budget** (`aider/repomap.py:47`, default `map_tokens=1024`).
+  - **The key difference (an absence-of-claim)**: Aider **never claims repo-map saves X%** — the repo map is an **overhead** that "buys" capability with a fixed budget, not a saving relative to whole-file feeding. This is the exact opposite of the MCP retrieval tools' marketing frame.
+
+### ③ Output-side diff-edit (most directly tied to "output tokens")
+
+- **Mechanism**: diff / SEARCH-REPLACE returns only the changed hunk instead of rewriting the whole file (whole-file = "slow and costly because the LLM has to return the entire file").
+- **Representatives**: Aider's `diff`/`udiff` (unified diff) formats, Claude Code's built-in `old_string`/`new_string` Edit tool, OpenAI's `apply_patch` V4A.
+- **Concrete positive example**: Aider's unified diff lifted GPT-4 Turbo's lazy-coding benchmark from 20% to 61% (output compression **sometimes actually improves capability**).
+- **Cost**: format fragility — same source: "disabling flexible patching yields a 9x increase in editing errors"; weak models actually regress in accuracy when using diff (see "User Evidence", Aider).
+
+### ④ Context middleware / long-term memory
+
+- **mem0** (arXiv 2504.19413): extracts salient facts across sessions into a vector DB, replacing replay of the full dialogue history. Claims "saves more than 90% token cost".
+  - **Measurement trap**: the >90% is vs the baseline of "replaying 16k~26k tokens of full history every time" — token saving is guaranteed by the mechanism; the entire dispute is about accuracy (see "User Evidence").
+- **SuperClaude** (23.6k★): a "behavior framework" that injects markdown instruction files into context. The v1 README claimed "70% reduction"; the current version walks it back to "30-50% fewer tokens" — **both generations have zero methodology**.
+- **Anthropic official**: context editing + memory tool (claims 84% @ 100-turn web search), Tool Search Tool (85% saving on input-side tool definitions). All numbers are internal and unreplicated, but the mechanism is transparent.
+
+### ⑤ Model routing / caching proxy
+
+- **RouteLLM** (arXiv 2406.18665): trains a strong/weak model router, sending simple tasks to the cheaper model. Claims "85% cost saving + retains 95% of GPT-4 capability", but **only tested on MT Bench/MMLU/GSM8K, no coding**.
+- **claude-code-router** (35.8k★): a local proxy that routes Claude Code's various traffic to cheaper models. Makes no % saving claim of its own.
+- **prompt caching**: saves **cost, not tokens**, and cache writes carry a 1.25×/2× premium — at low hit rates it is actually more expensive.
+
+---
+
+## Deep Dive: SWE-Pruner — the strongest "saves tokens without dropping success rate" evidence in this survey
+
+(arXiv 2601.16746 v4, github.com/Ayanami1314/swe-pruner, 299★)
+
+This one deserves its own section because it is **simultaneously the strongest counterexample to LLMLingua-style pruning and the strongest positive case for line-level pruning**:
+
+- **Two key differences from LLMLingua's mechanism**:
+  - **task-aware**: the agent first gives an explicit goal (e.g. "focus on error handling") to guide pruning, instead of a fixed perplexity metric.
+  - **line-level, not token-level**: a 0.6B skimmer keeps or deletes whole lines, so it **does not produce LLMLingua-style surface corruption**.
+- **Positive numbers (full 500-question SWE-bench Verified)**:
+  - Claude Sonnet 4.5: success rate 70.6% → **72.0% (+1.4 pts)**, tokens −23.1%
+  - GLM-4.6: 55.4% → 56.6% (+1.2 pts), tokens −38.3%
+- **Hard proof of the mechanistic divide (AST validity comparison, paper Table 8)**:
+
+  | Method | Post-compression AST validity |
+  |-|-|
+  | Full Context (uncompressed) | 98.5% |
+  | LLMLingua-2 (token-level) | **0.29%** |
+  | LongCodeZip (line-level) | 89.3% |
+  | SWE-Pruner (line-level) | 87.3% |
+
+- **Honest boundaries**: at single-turn 8x extreme compression, EM (Exact Match, the fraction of outputs identical word-for-word to the reference) still drops from 40.5 to 31.0 (a substantial regression); Python-only; single-team, zero third-party replication. **Rating: most worth verifying, but not yet safe to adopt with confidence.**
+
+---
+
+## User Evidence (Q3: distinguishing engineering bugs from mechanistic regression)
+
+All citations below carry an issue number/link and are traceable. Each is classified as "mechanistic regression" or "engineering bug".
+
+### Corroborating mechanistic regression
+
+- **LLMLingua #89** (open): a user measured on LongBench qasper that the wrong-answer/no-answer rate rose from 45.36% to 63.93% (+18 pts). **#136**: dureader accuracy 0.68 → 0.02. 【mechanistic】
+- **Serena**: Reddit r/ClaudeCode "Feels like Serena MCP uses more tokens than without?" — OP "I hit context limits faster with Serena than without", top reply confirms "any MCP will increase token usage". Cursor devs separately note "semantic search over codebases performs worse than letting the model search with bash". 【mechanistic: MCP schema fixed overhead】
+- **Aider**: an HN user posted logs showing the repo-map summary "produced multiple factually incorrect descriptions, hallucinating tracking mechanisms that don't exist"; on a 300-file monorepo "the repo map overwhelmed the LLM". 【mechanistic: compressed representation misleads — directly matches the "wrong answer / agent gets lost" suspicion】
+- **mem0 #5867** (open): a preference change (Ronaldo→Messi) produces two coexisting contradictory memories, "retrieval becomes ambiguous". An HN user turned off memory because it "keeps stale information and bleeds across projects". 【mechanistic】
+
+### Corroborating engineering bugs (but mostly inherent to that mechanism's risk surface)
+
+- **Serena #1529** (open): `replace_symbol_body` corrupts Go's `type Resampler struct` into `type type Resampler struct`, **and the tool returns `{"result": "OK"}` with no error at all** — silent corruption, directly matching the "corrupts code" suspicion. **#516**: Serena's own `search_for_pattern` returns 32,204 tokens in a single call, blowing past Claude Code's 25k MCP limit (a token-saving tool overshooting).
+- **claude-context #145 / #226 / #232**: indexing succeeds but then "codebase not indexed, never able to search"; state-sync bug; any project change requires re-indexing the whole thing.
+- **claude-mem #618** (confirmed bug): "Uses too much tokens — claude code consumes all my tokens within 10 messages" (a token-bloat bug in a flagship memory plugin).
+- **claude-code-router #1378** (open): DeepSeek + thinking + tool calls hits 400 every turn, "completely unusable as soon as it touches tools". 【mechanistic: protocol incompatibility → entire tool-use turn scrapped, the highest risk for a coding agent】
+
+### Aside: Claude Code /compact is everyone's baseline of comparison, and is itself the largest body of negative evidence
+
+- **#10006**: "every auto-compact, it loses every detail". **#13919**: skills stop working after compaction, task time goes from "~1 hour" to "5-6+ hours". Engineer's report: "definitely dumber after compaction, doesn't know what files it was just looking at".
+- Classification: CLAUDE.md/skills not being re-injected is an **engineering bug** (partly fixed in the current version); the summary dropping mid-task decisions/file lists is **mechanistic lossy compression**.
+
+### Balance: the retrieval direction also has positive independent evidence
+
+- **Cursor's official A/B** (2025-11): same model, semantic search vs grep-only, on average **12.5% higher accuracy** (6.5%~23.5%); large-codebase code retention +2.6%. — refutes the extreme reading that "retrieval necessarily makes a coding agent dumber".
+- But contrast Claude Code's official stance: "Claude Code currently doesn't use RAG (Retrieval-Augmented Generation, retrieve vectors first then feed the snippets to the model); in our testing agentic search outperformed RAG for the way people use Code".
+
+---
+
+## Should You Use It (practical guidance)
+
+- **Want to save with zero risk**: prefer the "near-lossless by mechanism" tools — targeted/diff edits (the format-compliance tax is negligible on Claude 4+ class models), noisy tool-output compression (only helps when output is dirty), tool-definition lazy loading, prompt caching (watch for cache-miss backfire and the write premium). Anthropic's built-in token-efficient tool use requires no adoption action — it's already built in.
+- **Large codebase (>20k LoC (lines of code) class) and willing to pay index maintenance cost**: only then are semantic retrieval tools worth it; expect the theoretical gains to be partly eaten by index desync and MCP fixed overhead.
+- **Never**: use token-level perplexity pruning (LLMLingua style) for coding; extrapolate 2024-era classifier routing's 85%/95% claims to agentic coding.
+- **General rule**: percentages with an unknown denominator are not comparable. Before citing any "saves X%", ask **what is measured (input/output/cost/a single subtask), under what workload, against which baseline**.
+
+---
+
+## 🧪 Critical Assessment
+
+### The boundaries of this audit itself
+
+- **Not a single number was measured on Claude Code**: all vendor numbers were measured on their own harness, model, and workload; extrapolating to Claude Code is inference. Closing the loop properly requires measuring a fixed task set under `claude -p` headless with `ccusage` (see the closure recipes in the original dossier).
+- **Reddit retrieval was limited**: this environment gets a blanket 403 from Reddit; most Reddit evidence went through the arctic-shift archive API or is marked secondary.
+- **SWE-Pruner's positive evidence is strong, but single-team, zero independent replication, Python-only** — it is "most worth verifying", not "already proven". Its paper Table 3 baseline (62.0%) is inconsistent with Table 1 (70.6%) and does not state the sample size — a discrepancy the paper itself never explains.
+
+### claim-laundering is widespread
+
+Many "token-saving" claims quietly swap their measurement basis when relayed through secondary blogs — e.g. LEANN's "97% less storage" gets mis-relayed as "saves 97% tokens" (storage ≠ tokens); code-context-engine's "94% fewer input tokens" uses a "read the entire file" straw-man baseline. Always go back to the primary page to confirm what dimension is being measured.
+
+### Evidence strength is extremely uneven
+
+It ranges from "public benchmark + AST checking" (SWE-Pruner, Aider) to "officially refuses benchmarks, uses LLM self-grading" (Serena) to "zero-methodology marketing numbers" (SuperClaude, most MCPs). The "Evidence strength" column (🟢/🟡/🔴) in the "WRAPUP Per-Tool Master Table" annotates each one; readers should not mistake "has a star count" for "has evidence".
+
+## 🔗 Related notes
+
+- [Vector Database Comparison](../VectorDatabaseComparison/) — the vector-DB selection behind semantic-retrieval tools (claude-context etc.), also a market-audit survey.
+- [Shepherd](../Shepherd/) — programmable control of agentic execution traces, relevant to the design trade-offs of context management / memory middleware.
+
+---
+*This note is a read-only market-audit output; all citations were retrieved on 2026-07-16 and, unless noted, come from pages actually opened. Full per-item evidence, 11 deep-dive entries, and 15 closure recipes for open questions are in the original dossier.*

--- a/domains/mlops/CodingAgentTokenEfficiency/README.zh-TW.md
+++ b/domains/mlops/CodingAgentTokenEfficiency/README.zh-TW.md
@@ -1,0 +1,224 @@
+# Coding Agent 省 Token 工具與論文調查 — 手段、代價、使用者實證
+
+> [English](./README.md) | **繁體中文**
+
+## 📇 Academic Context
+
+| Field | Value |
+|-|-|
+| Title | 號稱為 Claude Code / Codex 等 coding agent 節省 20~40% token 的專案與論文:手段、代價、使用者實證 |
+| Venue Kind | survey(跨 11 個代表性專案 + 30 餘個周邊工具/論文的市場稽核) |
+| Year | 2026 |
+| 調查日期 | 2026-07-16(所有網路來源抓取日期相同,除另註) |
+| 方法 | read-only 稽核:引文只取自實際開啟讀過的頁面(官方 blog / arXiv 全文 / GitHub API / HN Algolia / Reddit 存檔 API / 靜態 clone);每個承重宣稱至少跑一次反證搜尋;未執行任何下載程式碼 |
+
+> 這則筆記不是單篇論文摘要,而是一則市場稽核 survey。稽核對象是「為 coding agent 省 20~40% token」這類宣稱本身。**所有廠商數字一律先當成未驗證的 seed**,凡與一手來源衝突,一手來源勝出;每個宣稱都追問「量的是什麼、什麼工作負載、baseline 是誰」。
+
+---
+
+## 一句話結論
+
+> **「省 20~40%」這個帶寬本身可信,但它是各家 60~95% 行銷數字被獨立量測打折後的殘值,而不是任何一家的原始宣稱。** 手段的風險差異極大:輸出側精簡與延遲載入幾乎無損;token 級剪枝(LLMLingua 型)用在 coding 是災難;檢索取代整檔餵入方向對,但實作品質常吃掉理論收益。
+
+一個對照最能說明問題:唯一一份**中立、同任務、同機器**的橫測(ComputingForGeeks,baseline 284,473 tokens),把一票自稱省 60~95% 的工具實測成 **0~43%**:
+
+| 工具 | 自稱 | 中立橫測實測 |
+|-|-|-|
+| token-savior | −80% | **43%** |
+| caveman | 65% | **38% / 37%** |
+| ooples token-optimizer-mcp | 95%+ | **23%** |
+| RTK | 60~90% | **0%**(輸出乾淨時完全沒省) |
+| code-review-graph | — | **5%**(小 repo 反而 0.7x 變貴) |
+
+使用者印象中的「20~40%」跟獨立量測對得上,跟廠商標題(60~95%)對不上。
+
+---
+
+## 三個調查問題
+
+這份稽核要回答的三個問題:
+
+- **Q1 — 手段**:這些專案各自透過什麼機制減少 token?每個機制都要有**具體例子**(repo 內實際的檔案/函式,或 paper 內實際的演算法/表格),而不只是行銷語言的轉述。
+- **Q2 — 代價**:除了 token 減少,這些手段是否會影響 LLM 的**能力與正確性**?各專案自己提供了什麼評測證據?有沒有獨立第三方評測?證據的強度與缺口在哪?
+- **Q3 — 使用者實證**:使用者的心得分享、GitHub issues、社群討論回報的問題/bug,是否指向 Q2 的懷疑(漏掉關鍵 context、改錯檔、答非所問、agent 迷路)?
+
+### 速查結論
+
+| 問題 | 結論 |
+|-|-|
+| **Q1 手段** | 五類機制:①token 級 prompt 壓縮 ②語意/符號檢索取代整檔讀取 ③context 中介層/長期記憶 ④輸出側 diff-edit ⑤模型路由/快取 proxy。詳見〈手段分類〉 |
+| **Q2 代價** | 差異巨大且可分層(見下方風險表)。最關鍵發現:token 級 perplexity(困惑度,衡量模型對一段文字的「意外」程度)剪枝會破壞 coding 的識別符/數值/語法(壓縮後 AST(抽象語法樹,Abstract Syntax Tree)正確率僅 **0.29%**);而**行級 task-aware 剪枝**(SWE-Pruner)在全量 SWE-bench Verified 上 −23~38% token 且成功率**反升** 1.2~1.4 個百分點(pts,percentage points) |
+| **Q3 使用者實證** | 大量印證 Q2 的懷疑:Serena「用了反而更快撞 context 上限」+ 靜默改壞碼;claude-context 索引失同步「從來搜不到」;mem0 存出互相矛盾的記憶;Claude Code 自己的 /compact 是最大宗「壓縮後失憶」抱怨來源 |
+
+---
+
+## 核心:按風險分層(Q2:能力與正確性的代價)
+
+把所有手段依「省 token 是否傷能力」排序,是這份調查最有用的產出,也是 Q2 的總答:
+
+| 風險 | 手段 | 為什麼 |
+|-|-|-|
+| 🟢 **最低** | diff / targeted edits(輸出側)、噪音工具輸出壓縮(RTK 型)、tool-definition 延遲載入、prompt caching | 機制上近無損;Anthropic 自家 token-efficient tool use(平均 14%)是唯一「大規模部署且查無退化回報」的案例 |
+| 🟡 **中** | 語意/符號檢索取代整檔餵入(Serena、claude-context);**行級 task-aware context 剪枝(SWE-Pruner)** | 方向有獨立正面證據(Cursor A/B(A/B test,對照實驗):+12.5% 準確率),但實作層(索引失同步、MCP(Model Context Protocol,模型上下文協定)固定開銷、符號編輯損毀)常吃掉收益;SWE-Pruner 證據面全場最強,但單一團隊、零重現、僅 Python |
+| 🔴 **高** | **token 級 / perplexity 剪枝(LLMLingua 型)用於 coding**;分類器模型路由用於 agentic coding | 多個獨立來源一致顯示破壞識別符/數值/AST;路由在 OOD(out-of-distribution,分布外,即測試情境與訓練資料不同)coding 崩壞 + 協定不相容導致 tool use 整段報廢 |
+| ⚫ **無法評估** | 零方法論的行為注入框架(SuperClaude 型)、零方法論的「95%+」MCP | 無 benchmark、無方法論,甚至有反向實測(框架自身先吃掉 4 萬多 token context) |
+
+> 注意:🔴 的判定**只限 token 級剪枝**,不延伸到行級 task-aware 剪枝 —— 兩者機制不同族,見〈手段分類 ①〉與〈深入:SWE-Pruner〉。
+
+### WRAPUP:逐工具總表
+
+一眼看完的主表。**機制**:A=token 級壓縮、B=檢索取代整檔、C=context 中介/記憶、D=輸出側 diff、E=路由/快取。**證據強度**(與能力風險同一套顏色,🟢=好、🔴=差):🟢 有公開 benchmark 可(原則上)重現;🟡 只有廠商自測或樣本過小;🔴 無方法論或明文拒絕評測(含只用 LLM 自評)。**能力風險**沿用上方風險分層:🟢 最低、🟡 中、🔴 高、⚫ 無法評估(零方法論、連傷不傷能力都判斷不了)。
+
+| 專案 | 機制 | 宣稱節省(量測口徑) | 證據強度 | 能力風險 | 使用者負面訊號 |
+|-|-|-|-|-|-|
+| SWE-Pruner | A(行級) | 23~54% token(agent 總 token,成功率反升) | 🟢 單一團隊、零重現 | 🟡 | 未找到(但部署量小) |
+| Aider(repo-map + diff) | B+D | 不宣稱 %(repo-map 是開銷) | 🟢 全場最誠實 | 🟢 diff(強模型)/🟡 repo-map | 有:#752 預算超標 16 倍、SEARCH-REPLACE 失敗群 |
+| claude-context | B | ~40%(30 題 localization) | 🟡 n=30、弱模型 | 🟡 | 有:索引失同步 #145/#226/#232 |
+| LLMLingua 家族 | A(token 級) | up to 20x(input tokens,CoT 任務) | 🟡 官方窄 / coding 被獨立證據打穿 | 🔴(coding) | 有:#89 錯答率 +18pts、#136 崩到 0.02 |
+| mem0 | C | >90%(vs 重播全史) | 🟡 高度爭議 | 🟡 | 有:#5867 矛盾記憶 |
+| Anthropic 官方功能 | C/D/E | 84% / 14~70% / 85% / 98.7%(internal) | 🟡 internal-only,機制透明 | 🟢 | 少;唯 /compact 有大量「失憶」抱怨 |
+| RouteLLM | E | 85% 省費 + 保 95%(無 coding) | 🟡 in-domain / 崩 OOD | 🔴(agentic) | 學術反證強、repo 無明顯抱怨 |
+| Serena | B | 無數字(社群傳 70%,查無據) | 🔴 明文拒測、LLM 自評 | 🟡 | 有:Reddit「反而更耗」、#1529 靜默改壞碼 |
+| SuperClaude | C | 70%→30-50%(零方法論) | 🔴 | ⚫ | 有:#286 框架自吃 43.8k context |
+| claude-code-router | E | 自身無 % 宣稱 | 🔴 無評測 | 🔴 協定不相容 | 有:#1378 tool use 全滅 |
+| token-savior | B/C/D | −80% 自稱 → 中立 43% | 🔴 自製 tsbench | 🟡 未嚴謹評測能力 | — |
+| caveman | D(強制電報體輸出) | 65% 自稱 → 中立 38% | 🔴 自測 | 🟢 中立測「答案相同」;但 terse 工作負載可能反增 | — |
+| ooples token-optimizer-mcp | B/D | 95%+ 自稱 → 中立 23% | 🔴 零方法論 | 🟡 未評測 | — |
+| RTK | D(壓噪音輸出) | 60~90% 自稱 → 中立 0% | 🔴 自測 | 🟢 只壓噪音、風險低 | — |
+| code-review-graph | B(圖檢索) | 中立 5%(小 repo 反而 0.7x 變貴) | 🔴 | 🟡 未評測 | — |
+| 其他(claude-mem、Headroom 等) | C/D | 10x、~50%(自稱) | 🔴 自測 | 🟡 | 有:claude-mem #618 token 膨脹 |
+
+---
+
+## 手段分類(Q1:機制 + 具體例子)
+
+### ① Token 級 prompt 壓縮 — LLMLingua 家族
+
+- **代表**:LLMLingua / LongLLMLingua / LLMLingua-2(Microsoft,arXiv 2310.05736 / 2310.06839 / 2403.12968)
+- **機制**:用小型語言模型算每個 token 的 perplexity,把「低資訊」token 直接刪掉。
+- **具體例子**:官方 README 把一段 2,365-token 的 GSM8K CoT(chain-of-thought,思維鏈,要求模型逐步推理的 prompt)prompt 壓到 211 tokens(11.2x)。但官方自己的範例輸出就已損毀:*"He reanged five of boxes into packages of sixlters each..."* —— 行銷頁上的示例已展示了機制代價。
+- **官方甚至內建「修復」**:LongLLMLingua 有一個 subsequence recovery 步驟,把被壓壞的實體(如 "209" 修回 "2009")事後補回 —— 等於官方承認壓縮會破壞字面。
+- **宣稱口徑**:「up to 20x compression with minimal performance loss」量的是 **input prompt tokens**,工作負載是 GSM8K/BBH 的 CoT + GPT-3.5-0613。
+
+### ② 語意 / 符號檢索取代整檔讀取
+
+用精準檢索取代「把整個檔案塞進 context」。
+
+- **Serena MCP**(26.5k★):以 LSP(Language Server Protocol,語言伺服器協定,IDE 用來取得符號/定義/引用的標準介面)做符號級檢索,工具用符號名路徑(`MyClass/my_method`)取代整檔讀取。
+  - 程式碼:`FindSymbolTool`(`src/serena/tools/symbol_tools.py:132`,參數 `include_body` 註明 "Use judiciously")、`GetSymbolsOverviewTool`(`:36`)、`ReplaceSymbolBodyTool`(`:571`)。
+  - **官方自家 eval 的真實例子**:`get_symbols_overview` 一次呼叫回 ~2.5KB JSON vs Grep ~3KB;官方原話節省幅度是 *"saves ~1 call and some context window tokens per navigation"* —— 遠小於社群流傳的「省 70%」(該 70% 查無出處)。
+- **claude-context**(Zilliz,12.1k★):AST-aware 切塊 → embedding → Milvus 向量庫 → 混合檢索。
+  - **唯一「原則上可重現」的 vendor 量測**(repo `evaluation/README.md`):30 題 SWE-bench Verified 檢索子任務、GPT-4o-mini,tokens 73,373 → 44,449(**−39.4%**)、F1(精確率與召回率的調和平均,越高代表找對檔案的能力越好)0.40 vs 0.40 持平。這就是行銷句「Cut Token Waste by 40%」的全部實驗基礎。
+  - 弱點:n=30、限定 2-file 改動、用最受檢索恩惠的弱模型、只測 file localization(F1=0.40 表示兩組都過半機率找錯檔)。
+- **Aider repo-map**(全場定位最誠實):用 tree-sitter 抽符號 + PageRank 排名,**二分搜尋塞進固定 token 預算**(`aider/repomap.py:47`,預設 `map_tokens=1024`)。
+  - **關鍵差異(缺席事實)**:Aider **從不宣稱 repo-map 省 X%** —— repo map 是用固定預算「買」能力的**開銷**,不是相對整檔餵入的節省。這跟 MCP 檢索工具的行銷框架正好相反。
+
+### ③ 輸出側 diff-edit(與「輸出 token」最對口)
+
+- **機制**:diff / SEARCH-REPLACE 只回傳變更的 hunk,取代整檔重寫(整檔 = "slow and costly because the LLM has to return the entire file")。
+- **代表**:Aider 的 `diff`/`udiff`(unified diff,統一差異格式)格式、Claude Code 內建的 `old_string`/`new_string` Edit tool、OpenAI 的 `apply_patch` V4A。
+- **具體正面例子**:Aider 的 unified diff 把 GPT-4 Turbo 的 lazy-coding benchmark 從 20% 拉到 61%(輸出壓縮**有時反而提升能力**)。
+- **代價**:格式脆弱 —— 同文「關掉彈性 patching 時編輯錯誤增加 9 倍」;弱模型用 diff 準確率反而倒退(見〈使用者實證〉Aider)。
+
+### ④ Context 中介層 / 長期記憶
+
+- **mem0**(arXiv 2504.19413):跨 session 抽取重點事實進向量庫,取代重播全部對話史。宣稱 "saves more than 90% token cost"。
+  - **口徑陷阱**:>90% 是 vs「每次重播 16k~26k token 全史」這個 baseline —— 省 token 是機制上保送的,爭點全在準確率(見〈使用者實證〉)。
+- **SuperClaude**(23.6k★):把 markdown 指令檔注入 context 的「行為框架」。v1 README 宣稱 "70% reduction",現版改口 "30-50% fewer tokens" —— **兩代皆零方法論**。
+- **Anthropic 官方**:context editing + memory tool(宣稱 84% @ 100-turn web search)、Tool Search Tool(85% 省 input 側 tool definitions)。數字全部 internal、無獨立重現,但機制透明。
+
+### ⑤ 模型路由 / 快取 proxy
+
+- **RouteLLM**(arXiv 2406.18665):訓練強/弱模型路由器,簡單任務派便宜模型。宣稱「85% 省費用 + 保 95% GPT-4 能力」,但**只測 MT Bench/MMLU/GSM8K,無 coding**。
+- **claude-code-router**(35.8k★):本地 proxy 把 Claude Code 各類流量路由到便宜模型。自身不宣稱 % 節省。
+- **prompt caching**:省的是**費用不是 token**,且寫入有 1.25×/2× 溢價 —— 低命中率時反而更貴。
+
+---
+
+## 深入:SWE-Pruner —— 本次調查中最強的「省 token 且成功率不降」證據
+
+(arXiv 2601.16746 v4,github.com/Ayanami1314/swe-pruner,299★)
+
+這篇值得單獨拉出來,因為它**同時是 LLMLingua 型剪枝的最強反例、也是行級剪枝的最強正例**:
+
+- **機制與 LLMLingua 的兩個關鍵分野**:
+  - **task-aware**:agent 先給一個明確目標(如 "focus on error handling")引導剪枝,而非固定 perplexity 指標。
+  - **行級而非 token 級**:0.6B 的 skimmer 整行保留或整行刪除,故**不產生 LLMLingua 式的字面損毀**。
+- **正面數字(全量 500 題 SWE-bench Verified)**:
+  - Claude Sonnet 4.5:成功率 70.6% → **72.0%(+1.4 pts)**,tokens −23.1%
+  - GLM-4.6:55.4% → 56.6%(+1.2 pts),tokens −38.3%
+- **機制性分野的鐵證(AST 正確率對照,paper Table 8)**:
+
+  | 方法 | 壓縮後 AST 正確率 |
+  |-|-|
+  | Full Context(完整 context,不壓縮) | 98.5% |
+  | LLMLingua-2(token 級) | **0.29%** |
+  | LongCodeZip(行級) | 89.3% |
+  | SWE-Pruner(行級) | 87.3% |
+
+- **誠實邊界**:單輪 8x 極限壓縮時 EM(Exact Match,完全匹配率,輸出與標準答案逐字一致的比例)仍從 40.5 掉到 31.0(有實質退化);僅 Python;單一團隊、零第三方重現。**評級:最值得驗證,但尚不足以放心採用。**
+
+---
+
+## 使用者實證(Q3:區分工程 bug vs 機制性退化)
+
+以下引用皆附 issue 編號/連結,可回溯。分類標明是「機制性退化」還是「工程 bug」。
+
+### 印證機制性退化
+
+- **LLMLingua #89**(open):使用者在 LongBench qasper 實測,錯答/棄答率從 45.36% 升到 63.93%(+18 pts)。**#136**:dureader 準確率 0.68 → 0.02。【機制性】
+- **Serena**:Reddit r/ClaudeCode「Feels like Serena MCP uses more tokens than without?」—— OP「用 Serena 反而更快撞 context 上限」,最高讚回覆證實「任何 MCP 都會增加 token」。另有 cursor devs 指出「語意檢索在 codebase 上表現比讓模型自己用 bash 搜還差」。【機制性:MCP schema 固定開銷】
+- **Aider**:HN 使用者貼 log 指 repo-map 摘要「產生多個事實錯誤的描述、幻想出不存在的追蹤機制」;300-file monorepo 上「repo map 把 LLM 淹沒」。【機制性:壓縮表徵誤導 —— 正對「答非所問/agent 迷路」懷疑】
+- **mem0 #5867**(open):偏好變更(Ronaldo→Messi)產生兩條並存的矛盾記憶,「檢索變得模稜兩可」。HN 使用者關掉記憶因為它「一直留著過時資訊、跨專案滲漏」。【機制性】
+
+### 印證工程 bug(但多屬該機制的固有風險面)
+
+- **Serena #1529**(open):`replace_symbol_body` 把 Go 的 `type Resampler struct` 改壞成 `type type Resampler struct`,**且工具回傳 `{"result": "OK"}` 完全不報錯** —— 靜默損毀,直接對應「改壞碼」懷疑。**#516**:Serena 自己的 `search_for_pattern` 單次回 32,204 tokens 爆掉 Claude Code 的 25k MCP 上限(省 token 工具反而超支)。
+- **claude-context #145 / #226 / #232**:索引成功但隨即「codebase not indexed、從來搜不到」;狀態同步 bug;專案一改動就要整包重索引。
+- **claude-mem #618**(confirmed bug):「Uses too much tokens —— claude code 在 10 則訊息內把我的 token 全吃光」(旗艦記憶插件的 token 膨脹 bug)。
+- **claude-code-router #1378**(open):DeepSeek + thinking + tool calls 每輪必 400,「一碰到 tools 就完全無法用」。【機制性:協定不相容 → tool use 整段報廢,對 coding agent 是最高風險】
+
+### 附帶:Claude Code /compact 是所有人比較的 baseline,自身即最大量負面實證
+
+- **#10006**:「每次 auto-compact,它丟掉每一個細節」。**#13919**:skills 在 compaction 後全失效,任務時間從「~1 小時」變「5-6+ 小時」。工程師實測:「compaction 後明顯變笨,不知道自己剛在看哪些檔案」。
+- 分類:CLAUDE.md/skills 不回注是**工程 bug**(現版已部分修復);摘要丟中途決策/檔案清單是**機制性有損壓縮**。
+
+### 平衡:檢索方向也有正面獨立證據
+
+- **Cursor 官方 A/B**(2025-11):同模型下 semantic search vs grep-only,平均**準確率高 12.5%**(6.5%~23.5%);大型 codebase code retention +2.6%。—— 反駁「檢索必然使 coding agent 變笨」的極端讀法。
+- 但對照 Claude Code 官方立場:「Claude Code 目前不用 RAG(Retrieval-Augmented Generation,檢索增強生成,先向量檢索再把片段餵給模型);我們測下來 agentic search 在 Code 的使用情境優於 RAG」。
+
+---
+
+## 該不該用(實務建議)
+
+- **想無腦省又不冒險**:優先用「機制上近無損」的手段 —— targeted/diff edits(Claude 4+ 級模型上格式順從稅可忽略)、噪音工具輸出壓縮(只在輸出髒時有效)、tool-definition 延遲載入、prompt caching(注意 cache-miss 反噬與寫入溢價)。Anthropic 內建的 token-efficient tool use 無需採用動作、已內建。
+- **大 codebase(>20k LoC(lines of code,程式碼行數)級)且願付索引維運成本**:才值得上語意檢索工具;預期理論收益會被索引失同步、MCP 固定開銷部分吃掉。
+- **絕不要**:把 token 級 perplexity 剪枝(LLMLingua 型)用在 coding;把 2024 式分類器路由的 85%/95% 宣稱外推到 agentic coding。
+- **通則**:分母不明的百分比不可比。引用任何「省 X%」前,先問**量什麼(input/output/費用/單一子任務)、什麼工作負載、baseline 是誰**。
+
+---
+
+## 🧪 Critical Assessment
+
+### 這份稽核本身的邊界
+
+- **沒有一個數字是在 Claude Code 上量的**:所有 vendor 數字都在各自的 harness、模型、工作負載上量出,外推到 Claude Code 都是推論。真正的閉環需要固定任務集在 `claude -p` headless 下用 `ccusage` 實測(見〈未解問題〉)。
+- **Reddit 取證受限**:本環境對 Reddit 全面 403,多數 Reddit 證據改走 arctic-shift 存檔 API 或標為 secondary。
+- **SWE-Pruner 的正面證據雖強,但單一團隊、零獨立重現、僅 Python** —— 它是「最值得驗證」而非「已證實」。其 paper Table 3 的 baseline(62.0%)與 Table 1(70.6%)不一致且未標明樣本數,是一個 paper 自己沒解釋的疑點。
+
+### claim-laundering(宣稱洗白)現象普遍
+
+不少「省 token」宣稱經二手部落格轉述後偷換了口徑,例如 LEANN 的「97% less storage」被誤傳成「省 97% token」(儲存 ≠ token);code-context-engine 的「94% fewer input tokens」baseline 是「整檔全讀」的稻草人。引用時務必回一手頁面確認量的維度。
+
+### 證據強度極不均
+
+從「有公開 benchmark + AST 檢核」(SWE-Pruner、Aider)到「官方明文拒絕 benchmark、用 LLM 自評」(Serena)到「零方法論的行銷數字」(SuperClaude、多數 MCP)都有。〈WRAPUP 逐工具總表〉的「證據強度」欄(🟢/🟡/🔴)已逐項標注,讀者不應把「有 star 數」當成「有證據」。
+
+## 🔗 Related notes
+
+- [Vector Database Comparison](../VectorDatabaseComparison/) — 語意檢索類工具(claude-context 等)背後的向量庫選型,同為市場稽核 survey 文類。
+- [Shepherd](../Shepherd/) — agentic execution trace 的可程式化控制,與 context 管理/記憶中介層的設計取捨相關。
+
+---
+*本筆記為 read-only 市場稽核產出;所有引文抓取日期均為 2026-07-16,除標註者外皆來自實際開啟之頁面。完整逐條證據、11 項深查與 15 條未解問題的 closure recipe 見原始 dossier。*

--- a/domains/mlops/README.md
+++ b/domains/mlops/README.md
@@ -5,3 +5,4 @@
 |-|-|-|-|-|
 | [Vector Database Comparison: auditing issue #62 against 2026 primary sources](./VectorDatabaseComparison/) | survey | '26 | - | [✓](./VectorDatabaseComparison/) |
 | [Shepherd: Enabling Programmable Meta-Agents via Reversible Agentic Execution Traces](./Shepherd/) | unknown | '26 | [repo](https://github.com/shepherd-agents/shepherd) | [EN](./Shepherd/) · [中文](./Shepherd/README.zh-TW.md) |
+| [Token-Saving Tools & Papers for Coding Agents: mechanisms, costs, user evidence](./CodingAgentTokenEfficiency/) | survey | '26 | - | [EN](./CodingAgentTokenEfficiency/) · [中文](./CodingAgentTokenEfficiency/README.zh-TW.md) |


### PR DESCRIPTION
## What

A read-only **market-audit survey** of projects and papers that claim to save ~20–40% tokens for coding agents (Claude Code / Codex): their mechanisms, the cost to LLM capability/correctness, and corroborating user evidence from GitHub issues and community discussion.

Bilingual note (English default + 繁體中文) added under `domains/mlops/CodingAgentTokenEfficiency/`.

## Key findings

- **The "20–40%" band is real but is the residual after each vendor's 60–95% marketing number is discounted by independent measurement** — the only neutral same-task cross-test put self-claimed 60–95% tools at 0–43%.
- **Risk is tierable**: output-side diff/targeted edits and lazy loading are near-lossless; token-level perplexity pruning (LLMLingua) is a disaster for coding (post-compression AST validity 0.29%); line-level task-aware pruning (SWE-Pruner) hits −23–38% tokens while success rate *rises* 1.2–1.4 pts.
- **User evidence corroborates the capability-cost suspicion**: Serena "uses more tokens than without" + silent code corruption (#1529); claude-context index desync; mem0 contradictory memories; Claude Code /compact "amnesia" complaints.

## Structure

- Answers three questions (Q1 mechanism / Q2 cost / Q3 user evidence) explicitly.
- **WRAPUP per-tool master table**: mechanism · claimed saving (with measurement basis) · evidence strength (🟢/🟡/🔴) · capability risk (🟢/🟡/🔴/⚫) · negative user signal, across 16 tools.
- Every claim is cited (file:line, arXiv table, or issue number + quote); vendor numbers treated as unverified seeds.

## Files

- `domains/mlops/CodingAgentTokenEfficiency/README.md` (EN) + `README.zh-TW.md` (繁中)
- `domains/mlops/README.md` — index row

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pb2m3f3qKpLcfpR3w2hBe
