### PR TITLE
docs(mlops): escape tildes + strengthen SWE-Pruner / add prompt-caching conflict

### DIFF
--- a/domains/mlops/CodingAgentTokenEfficiency/README.md
+++ b/domains/mlops/CodingAgentTokenEfficiency/README.md
@@ -131,7 +131,7 @@ Replace "stuffing the whole file into context" with precise retrieval.
 
 - **RouteLLM** (arXiv 2406.18665): trains a strong/weak model router, sending simple tasks to the cheaper model. Claims "85% cost saving + retains 95% of GPT-4 capability", but **only tested on MT Bench/MMLU/GSM8K, no coding**.
 - **claude-code-router** (35.8k★): a local proxy that routes Claude Code's various traffic to cheaper models. Makes no % saving claim of its own.
-- **prompt caching**: saves **cost, not tokens**, and cache writes carry a 1.25×/2× premium — at low hit rates it is actually more expensive.
+- **prompt caching**: saves **cost, not tokens**, and cache writes carry a 1.25×/2× premium — at low hit rates it is actually more expensive. **It also largely conflicts with most dynamic token-saving methods (see "Should You Use It").**
 
 ---
 
@@ -156,7 +156,8 @@ This one deserves its own section because it is **simultaneously the strongest c
   | LongCodeZip (line-level) | 89.3% |
   | SWE-Pruner (line-level) | 87.3% |
 
-- **Honest boundaries**: at single-turn 8x extreme compression, EM (Exact Match, the fraction of outputs identical word-for-word to the reference) still drops from 40.5 to 31.0 (a substantial regression); Python-only; single-team, zero third-party replication. **Rating: most worth verifying, but not yet safe to adopt with confidence.**
+- **Honest boundaries**: at single-turn 8x extreme compression, EM (Exact Match, the fraction of outputs identical word-for-word to the reference) still drops from 40.5 to 31.0 (a substantial regression); Python-only; single-team, zero third-party replication.
+- **Rating: very likely a genuinely adoptable method with reference value.** It is the only direction in this survey with full public data behind "saves a lot (−23\~38% tokens) without losing capability (success rate rises)", and its mechanism (line-level task-aware) is sound — worth using as a design reference. The only reason it isn't yet in the 🟢 "adopt with confidence" tier is insufficient external validation (single-team, zero replication, Python-only), not any flaw in the mechanism or the data — so verify it on your own codebase (closure recipe #15) before adopting, rather than either copying it blindly or dismissing it.
 
 ---
 
@@ -194,6 +195,8 @@ All citations below carry an issue number/link and are traceable. Each is classi
 
 - **Want to save with zero risk**: prefer the "near-lossless by mechanism" tools — targeted/diff edits (the format-compliance tax is negligible on Claude 4+ class models), noisy tool-output compression (only helps when output is dirty), tool-definition lazy loading, prompt caching (watch for cache-miss backfire and the write premium). Anthropic's built-in token-efficient tool use requires no adoption action — it's already built in.
 - **Large codebase (>20k LoC (lines of code) class) and willing to pay index maintenance cost**: only then are semantic retrieval tools worth it; expect the theoretical gains to be partly eaten by index desync and MCP fixed overhead.
+- **The most promising new direction to track**: SWE-Pruner-style **line-level task-aware pruning** is very likely usable and worth referencing — the only approach with full public data behind "saves a lot without losing capability". Before adopting, self-host the skimmer and measure on your own codebase with `ccusage` (closure recipe #15), but don't dismiss it just because it's a preprint from a single team.
+- **⚠️ prompt caching largely conflicts with dynamic token-saving methods — don't naively stack them**: prompt caching only earns the 0.1x cache-read discount when the prompt prefix is byte-stable and only appended to at the tail; but most dynamic context-shrinking methods (LLMLingua compression, SWE-Pruner pruning, Anthropic context editing clearing old tool calls, memory/summary rewriting) **mutate the prefix every turn**, and any mutation invalidates the cache from that point on → back to full-price misses + the 1.25×/2× write premium, so stacking the two can cost more than either alone. The two strategies pull in opposite directions: caching wants a stable, append-only context; aggressive pruning wants to mutate-and-shrink. Pick one by cost structure — if cost is dominated by a repeated stable long prefix, choose caching; if by unbounded growing context, choose pruning.
 - **Never**: use token-level perplexity pruning (LLMLingua style) for coding; extrapolate 2024-era classifier routing's 85%/95% claims to agentic coding.
 - **General rule**: percentages with an unknown denominator are not comparable. Before citing any "saves X%", ask **what is measured (input/output/cost/a single subtask), under what workload, against which baseline**.
 

--- a/domains/mlops/CodingAgentTokenEfficiency/README.md
+++ b/domains/mlops/CodingAgentTokenEfficiency/README.md
@@ -6,31 +6,31 @@
 
 | Field | Value |
 |-|-|
-| Title | Projects and papers claiming to save 20~40% tokens for coding agents like Claude Code / Codex: mechanisms, costs, and user evidence |
+| Title | Projects and papers claiming to save 20\~40% tokens for coding agents like Claude Code / Codex: mechanisms, costs, and user evidence |
 | Venue Kind | survey (a market audit across 11 representative projects + 30-odd peripheral tools/papers) |
 | Year | 2026 |
 | Survey date | 2026-07-16 (all web sources retrieved on the same date unless noted) |
 | Method | read-only audit: citations only from pages actually opened and read (official blogs / arXiv full text / GitHub API / HN Algolia / Reddit archive API / static clone); every load-bearing claim ran at least one refutation search; no downloaded code was executed |
 
-> This note is not a single-paper summary but a market-audit survey. The audit target is the *claim itself* that a tool "saves 20~40% tokens for coding agents." **Every vendor number is treated first as an unverified seed**; whenever it conflicts with a primary source, the primary source wins. Each claim is interrogated with "what is being measured, under what workload, and against which baseline?"
+> This note is not a single-paper summary but a market-audit survey. The audit target is the *claim itself* that a tool "saves 20\~40% tokens for coding agents." **Every vendor number is treated first as an unverified seed**; whenever it conflicts with a primary source, the primary source wins. Each claim is interrogated with "what is being measured, under what workload, and against which baseline?"
 
 ---
 
 ## One-Sentence Conclusion
 
-> **The "20~40% saving" band is itself credible — but it is the residual left after each vendor's 60~95% marketing number is discounted by independent measurement, not any vendor's original claim.** Risk varies enormously across mechanisms: output-side trimming and lazy loading are nearly lossless; token-level pruning (LLMLingua style) is a disaster for coding; retrieval-instead-of-whole-file is the right direction but implementation quality often eats the theoretical gains.
+> **The "20\~40% saving" band is itself credible — but it is the residual left after each vendor's 60\~95% marketing number is discounted by independent measurement, not any vendor's original claim.** Risk varies enormously across mechanisms: output-side trimming and lazy loading are nearly lossless; token-level pruning (LLMLingua style) is a disaster for coding; retrieval-instead-of-whole-file is the right direction but implementation quality often eats the theoretical gains.
 
-One comparison says it best: the only **neutral, same-task, same-machine** cross-test (ComputingForGeeks, baseline 284,473 tokens) measured a batch of tools that self-claim 60~95% savings at **0~43%**:
+One comparison says it best: the only **neutral, same-task, same-machine** cross-test (ComputingForGeeks, baseline 284,473 tokens) measured a batch of tools that self-claim 60\~95% savings at **0\~43%**:
 
 | Tool | Self-claimed | Neutral cross-test |
 |-|-|-|
 | token-savior | −80% | **43%** |
 | caveman | 65% | **38% / 37%** |
 | ooples token-optimizer-mcp | 95%+ | **23%** |
-| RTK | 60~90% | **0%** (no saving at all when output is clean) |
+| RTK | 60\~90% | **0%** (no saving at all when output is clean) |
 | code-review-graph | — | **5%** (on small repos it is 0.7x — actually more expensive) |
 
-Users' impression of "20~40%" lines up with independent measurement — not with the vendor headlines (60~95%).
+Users' impression of "20\~40%" lines up with independent measurement — not with the vendor headlines (60\~95%).
 
 ---
 
@@ -47,7 +47,7 @@ The three questions this audit answers:
 | Question | Conclusion |
 |-|-|
 | **Q1 Mechanism** | Five mechanism classes: ① token-level prompt compression ② semantic/symbol retrieval replacing whole-file reads ③ context middleware / long-term memory ④ output-side diff-edit ⑤ model routing / caching proxy. See "Mechanism Taxonomy". |
-| **Q2 Cost** | Huge variation, and tierable (see risk table below). Key finding: token-level perplexity (a measure of how "surprised" the model is by a span of text) pruning breaks coding identifiers/values/syntax (post-compression AST (Abstract Syntax Tree) validity is only **0.29%**); whereas **line-level task-aware pruning** (SWE-Pruner) achieves −23~38% tokens on the full SWE-bench Verified while success rate **rises** by 1.2~1.4 percentage points (pts). |
+| **Q2 Cost** | Huge variation, and tierable (see risk table below). Key finding: token-level perplexity (a measure of how "surprised" the model is by a span of text) pruning breaks coding identifiers/values/syntax (post-compression AST (Abstract Syntax Tree) validity is only **0.29%**); whereas **line-level task-aware pruning** (SWE-Pruner) achieves −23\~38% tokens on the full SWE-bench Verified while success rate **rises** by 1.2\~1.4 percentage points (pts). |
 | **Q3 User evidence** | Heavily corroborates the Q2 suspicion: Serena "hits context limits faster than without it" + silently corrupts code; claude-context index desync "never able to search"; mem0 stores mutually contradictory memories; Claude Code's own /compact is the single largest source of "amnesia after compression" complaints. |
 
 ---
@@ -71,12 +71,12 @@ The master table at a glance. **Mechanism**: A=token-level compression, B=retrie
 
 | Project | Mechanism | Claimed saving (measurement basis) | Evidence strength | Capability risk | Negative user signal |
 |-|-|-|-|-|-|
-| SWE-Pruner | A (line-level) | 23~54% token (agent total tokens, success rate rises) | 🟢 single-team, zero replication | 🟡 | none found (but small deployment base) |
+| SWE-Pruner | A (line-level) | 23\~54% token (agent total tokens, success rate rises) | 🟢 single-team, zero replication | 🟡 | none found (but small deployment base) |
 | Aider (repo-map + diff) | B+D | claims no % (repo-map is an overhead) | 🟢 most honest of all | 🟢 diff (strong models) / 🟡 repo-map | yes: #752 budget overshoot 16x, SEARCH-REPLACE failure cluster |
-| claude-context | B | ~40% (30-question localization) | 🟡 n=30, weak model | 🟡 | yes: index desync #145/#226/#232 |
+| claude-context | B | \~40% (30-question localization) | 🟡 n=30, weak model | 🟡 | yes: index desync #145/#226/#232 |
 | LLMLingua family | A (token-level) | up to 20x (input tokens, CoT tasks) | 🟡 official narrow / punctured on coding by independent evidence | 🔴 (coding) | yes: #89 error rate +18pts, #136 collapses to 0.02 |
 | mem0 | C | >90% (vs replaying full history) | 🟡 highly disputed | 🟡 | yes: #5867 contradictory memories |
-| Anthropic official features | C/D/E | 84% / 14~70% / 85% / 98.7% (internal) | 🟡 internal-only, mechanism transparent | 🟢 | few; only /compact draws many "amnesia" complaints |
+| Anthropic official features | C/D/E | 84% / 14\~70% / 85% / 98.7% (internal) | 🟡 internal-only, mechanism transparent | 🟢 | few; only /compact draws many "amnesia" complaints |
 | RouteLLM | E | 85% cost saving + retains 95% (no coding) | 🟡 in-domain / collapses OOD | 🔴 (agentic) | strong academic refutation, no notable repo complaints |
 | Serena | B | no number (community rumor of 70%, no source found) | 🔴 explicitly refuses testing, LLM self-grades | 🟡 | yes: Reddit "actually uses more", #1529 silent code corruption |
 | SuperClaude | C | 70%→30-50% (zero methodology) | 🔴 | ⚫ | yes: #286 framework itself eats 43.8k context |
@@ -84,9 +84,9 @@ The master table at a glance. **Mechanism**: A=token-level compression, B=retrie
 | token-savior | B/C/D | −80% self-claimed → neutral 43% | 🔴 self-made tsbench | 🟡 no rigorous capability test | — |
 | caveman | D (forces telegraphic output) | 65% self-claimed → neutral 38% | 🔴 self-test | 🟢 neutral test "same answers"; but terse workloads may net-increase | — |
 | ooples token-optimizer-mcp | B/D | 95%+ self-claimed → neutral 23% | 🔴 zero methodology | 🟡 untested | — |
-| RTK | D (compresses noisy output) | 60~90% self-claimed → neutral 0% | 🔴 self-test | 🟢 only compresses noise, low risk | — |
+| RTK | D (compresses noisy output) | 60\~90% self-claimed → neutral 0% | 🔴 self-test | 🟢 only compresses noise, low risk | — |
 | code-review-graph | B (graph retrieval) | neutral 5% (small repos 0.7x — more expensive) | 🔴 | 🟡 untested | — |
-| Others (claude-mem, Headroom, etc.) | C/D | 10x, ~50% (self-claimed) | 🔴 self-test | 🟡 | yes: claude-mem #618 token bloat |
+| Others (claude-mem, Headroom, etc.) | C/D | 10x, \~50% (self-claimed) | 🔴 self-test | 🟡 | yes: claude-mem #618 token bloat |
 
 ---
 
@@ -106,7 +106,7 @@ Replace "stuffing the whole file into context" with precise retrieval.
 
 - **Serena MCP** (26.5k★): symbol-level retrieval via LSP (Language Server Protocol, the standard interface an IDE uses to get symbols/definitions/references); tools use a symbol name path (`MyClass/my_method`) instead of reading the whole file.
   - Code: `FindSymbolTool` (`src/serena/tools/symbol_tools.py:132`, whose `include_body` param is annotated "Use judiciously"), `GetSymbolsOverviewTool` (`:36`), `ReplaceSymbolBodyTool` (`:571`).
-  - **The real example from its own eval**: `get_symbols_overview` returns ~2.5KB JSON per call vs Grep's ~3KB; the official phrasing for the saving is *"saves ~1 call and some context window tokens per navigation"* — far smaller than the community-rumored "70% saving" (that 70% has no traceable source).
+  - **The real example from its own eval**: `get_symbols_overview` returns \~2.5KB JSON per call vs Grep's \~3KB; the official phrasing for the saving is *"saves \~1 call and some context window tokens per navigation"* — far smaller than the community-rumored "70% saving" (that 70% has no traceable source).
 - **claude-context** (Zilliz, 12.1k★): AST-aware chunking → embedding → Milvus vector DB → hybrid retrieval.
   - **The only "in principle reproducible" vendor measurement** (repo `evaluation/README.md`): 30 SWE-bench Verified retrieval subtasks, GPT-4o-mini, tokens 73,373 → 44,449 (**−39.4%**), F1 (harmonic mean of precision and recall; higher = better at finding the right file) 0.40 vs 0.40 unchanged. This is the entire experimental basis for the marketing line "Cut Token Waste by 40%".
   - Weaknesses: n=30, restricted to 2-file changes, uses the weak model that benefits most from retrieval, tests only file localization (F1=0.40 means both groups have a >50% chance of picking the wrong file).
@@ -123,7 +123,7 @@ Replace "stuffing the whole file into context" with precise retrieval.
 ### ④ Context middleware / long-term memory
 
 - **mem0** (arXiv 2504.19413): extracts salient facts across sessions into a vector DB, replacing replay of the full dialogue history. Claims "saves more than 90% token cost".
-  - **Measurement trap**: the >90% is vs the baseline of "replaying 16k~26k tokens of full history every time" — token saving is guaranteed by the mechanism; the entire dispute is about accuracy (see "User Evidence").
+  - **Measurement trap**: the >90% is vs the baseline of "replaying 16k\~26k tokens of full history every time" — token saving is guaranteed by the mechanism; the entire dispute is about accuracy (see "User Evidence").
 - **SuperClaude** (23.6k★): a "behavior framework" that injects markdown instruction files into context. The v1 README claimed "70% reduction"; the current version walks it back to "30-50% fewer tokens" — **both generations have zero methodology**.
 - **Anthropic official**: context editing + memory tool (claims 84% @ 100-turn web search), Tool Search Tool (85% saving on input-side tool definitions). All numbers are internal and unreplicated, but the mechanism is transparent.
 
@@ -180,12 +180,12 @@ All citations below carry an issue number/link and are traceable. Each is classi
 
 ### Aside: Claude Code /compact is everyone's baseline of comparison, and is itself the largest body of negative evidence
 
-- **#10006**: "every auto-compact, it loses every detail". **#13919**: skills stop working after compaction, task time goes from "~1 hour" to "5-6+ hours". Engineer's report: "definitely dumber after compaction, doesn't know what files it was just looking at".
+- **#10006**: "every auto-compact, it loses every detail". **#13919**: skills stop working after compaction, task time goes from "\~1 hour" to "5-6+ hours". Engineer's report: "definitely dumber after compaction, doesn't know what files it was just looking at".
 - Classification: CLAUDE.md/skills not being re-injected is an **engineering bug** (partly fixed in the current version); the summary dropping mid-task decisions/file lists is **mechanistic lossy compression**.
 
 ### Balance: the retrieval direction also has positive independent evidence
 
-- **Cursor's official A/B** (2025-11): same model, semantic search vs grep-only, on average **12.5% higher accuracy** (6.5%~23.5%); large-codebase code retention +2.6%. — refutes the extreme reading that "retrieval necessarily makes a coding agent dumber".
+- **Cursor's official A/B** (2025-11): same model, semantic search vs grep-only, on average **12.5% higher accuracy** (6.5%\~23.5%); large-codebase code retention +2.6%. — refutes the extreme reading that "retrieval necessarily makes a coding agent dumber".
 - But contrast Claude Code's official stance: "Claude Code currently doesn't use RAG (Retrieval-Augmented Generation, retrieve vectors first then feed the snippets to the model); in our testing agentic search outperformed RAG for the way people use Code".
 
 ---

--- a/domains/mlops/CodingAgentTokenEfficiency/README.zh-TW.md
+++ b/domains/mlops/CodingAgentTokenEfficiency/README.zh-TW.md
@@ -6,31 +6,31 @@
 
 | Field | Value |
 |-|-|
-| Title | 號稱為 Claude Code / Codex 等 coding agent 節省 20~40% token 的專案與論文:手段、代價、使用者實證 |
+| Title | 號稱為 Claude Code / Codex 等 coding agent 節省 20\~40% token 的專案與論文:手段、代價、使用者實證 |
 | Venue Kind | survey(跨 11 個代表性專案 + 30 餘個周邊工具/論文的市場稽核) |
 | Year | 2026 |
 | 調查日期 | 2026-07-16(所有網路來源抓取日期相同,除另註) |
 | 方法 | read-only 稽核:引文只取自實際開啟讀過的頁面(官方 blog / arXiv 全文 / GitHub API / HN Algolia / Reddit 存檔 API / 靜態 clone);每個承重宣稱至少跑一次反證搜尋;未執行任何下載程式碼 |
 
-> 這則筆記不是單篇論文摘要,而是一則市場稽核 survey。稽核對象是「為 coding agent 省 20~40% token」這類宣稱本身。**所有廠商數字一律先當成未驗證的 seed**,凡與一手來源衝突,一手來源勝出;每個宣稱都追問「量的是什麼、什麼工作負載、baseline 是誰」。
+> 這則筆記不是單篇論文摘要,而是一則市場稽核 survey。稽核對象是「為 coding agent 省 20\~40% token」這類宣稱本身。**所有廠商數字一律先當成未驗證的 seed**,凡與一手來源衝突,一手來源勝出;每個宣稱都追問「量的是什麼、什麼工作負載、baseline 是誰」。
 
 ---
 
 ## 一句話結論
 
-> **「省 20~40%」這個帶寬本身可信,但它是各家 60~95% 行銷數字被獨立量測打折後的殘值,而不是任何一家的原始宣稱。** 手段的風險差異極大:輸出側精簡與延遲載入幾乎無損;token 級剪枝(LLMLingua 型)用在 coding 是災難;檢索取代整檔餵入方向對,但實作品質常吃掉理論收益。
+> **「省 20\~40%」這個帶寬本身可信,但它是各家 60\~95% 行銷數字被獨立量測打折後的殘值,而不是任何一家的原始宣稱。** 手段的風險差異極大:輸出側精簡與延遲載入幾乎無損;token 級剪枝(LLMLingua 型)用在 coding 是災難;檢索取代整檔餵入方向對,但實作品質常吃掉理論收益。
 
-一個對照最能說明問題:唯一一份**中立、同任務、同機器**的橫測(ComputingForGeeks,baseline 284,473 tokens),把一票自稱省 60~95% 的工具實測成 **0~43%**:
+一個對照最能說明問題:唯一一份**中立、同任務、同機器**的橫測(ComputingForGeeks,baseline 284,473 tokens),把一票自稱省 60\~95% 的工具實測成 **0\~43%**:
 
 | 工具 | 自稱 | 中立橫測實測 |
 |-|-|-|
 | token-savior | −80% | **43%** |
 | caveman | 65% | **38% / 37%** |
 | ooples token-optimizer-mcp | 95%+ | **23%** |
-| RTK | 60~90% | **0%**(輸出乾淨時完全沒省) |
+| RTK | 60\~90% | **0%**(輸出乾淨時完全沒省) |
 | code-review-graph | — | **5%**(小 repo 反而 0.7x 變貴) |
 
-使用者印象中的「20~40%」跟獨立量測對得上,跟廠商標題(60~95%)對不上。
+使用者印象中的「20\~40%」跟獨立量測對得上,跟廠商標題(60\~95%)對不上。
 
 ---
 
@@ -47,7 +47,7 @@
 | 問題 | 結論 |
 |-|-|
 | **Q1 手段** | 五類機制:①token 級 prompt 壓縮 ②語意/符號檢索取代整檔讀取 ③context 中介層/長期記憶 ④輸出側 diff-edit ⑤模型路由/快取 proxy。詳見〈手段分類〉 |
-| **Q2 代價** | 差異巨大且可分層(見下方風險表)。最關鍵發現:token 級 perplexity(困惑度,衡量模型對一段文字的「意外」程度)剪枝會破壞 coding 的識別符/數值/語法(壓縮後 AST(抽象語法樹,Abstract Syntax Tree)正確率僅 **0.29%**);而**行級 task-aware 剪枝**(SWE-Pruner)在全量 SWE-bench Verified 上 −23~38% token 且成功率**反升** 1.2~1.4 個百分點(pts,percentage points) |
+| **Q2 代價** | 差異巨大且可分層(見下方風險表)。最關鍵發現:token 級 perplexity(困惑度,衡量模型對一段文字的「意外」程度)剪枝會破壞 coding 的識別符/數值/語法(壓縮後 AST(抽象語法樹,Abstract Syntax Tree)正確率僅 **0.29%**);而**行級 task-aware 剪枝**(SWE-Pruner)在全量 SWE-bench Verified 上 −23\~38% token 且成功率**反升** 1.2\~1.4 個百分點(pts,percentage points) |
 | **Q3 使用者實證** | 大量印證 Q2 的懷疑:Serena「用了反而更快撞 context 上限」+ 靜默改壞碼;claude-context 索引失同步「從來搜不到」;mem0 存出互相矛盾的記憶;Claude Code 自己的 /compact 是最大宗「壓縮後失憶」抱怨來源 |
 
 ---
@@ -71,12 +71,12 @@
 
 | 專案 | 機制 | 宣稱節省(量測口徑) | 證據強度 | 能力風險 | 使用者負面訊號 |
 |-|-|-|-|-|-|
-| SWE-Pruner | A(行級) | 23~54% token(agent 總 token,成功率反升) | 🟢 單一團隊、零重現 | 🟡 | 未找到(但部署量小) |
+| SWE-Pruner | A(行級) | 23\~54% token(agent 總 token,成功率反升) | 🟢 單一團隊、零重現 | 🟡 | 未找到(但部署量小) |
 | Aider(repo-map + diff) | B+D | 不宣稱 %(repo-map 是開銷) | 🟢 全場最誠實 | 🟢 diff(強模型)/🟡 repo-map | 有:#752 預算超標 16 倍、SEARCH-REPLACE 失敗群 |
-| claude-context | B | ~40%(30 題 localization) | 🟡 n=30、弱模型 | 🟡 | 有:索引失同步 #145/#226/#232 |
+| claude-context | B | \~40%(30 題 localization) | 🟡 n=30、弱模型 | 🟡 | 有:索引失同步 #145/#226/#232 |
 | LLMLingua 家族 | A(token 級) | up to 20x(input tokens,CoT 任務) | 🟡 官方窄 / coding 被獨立證據打穿 | 🔴(coding) | 有:#89 錯答率 +18pts、#136 崩到 0.02 |
 | mem0 | C | >90%(vs 重播全史) | 🟡 高度爭議 | 🟡 | 有:#5867 矛盾記憶 |
-| Anthropic 官方功能 | C/D/E | 84% / 14~70% / 85% / 98.7%(internal) | 🟡 internal-only,機制透明 | 🟢 | 少;唯 /compact 有大量「失憶」抱怨 |
+| Anthropic 官方功能 | C/D/E | 84% / 14\~70% / 85% / 98.7%(internal) | 🟡 internal-only,機制透明 | 🟢 | 少;唯 /compact 有大量「失憶」抱怨 |
 | RouteLLM | E | 85% 省費 + 保 95%(無 coding) | 🟡 in-domain / 崩 OOD | 🔴(agentic) | 學術反證強、repo 無明顯抱怨 |
 | Serena | B | 無數字(社群傳 70%,查無據) | 🔴 明文拒測、LLM 自評 | 🟡 | 有:Reddit「反而更耗」、#1529 靜默改壞碼 |
 | SuperClaude | C | 70%→30-50%(零方法論) | 🔴 | ⚫ | 有:#286 框架自吃 43.8k context |
@@ -84,9 +84,9 @@
 | token-savior | B/C/D | −80% 自稱 → 中立 43% | 🔴 自製 tsbench | 🟡 未嚴謹評測能力 | — |
 | caveman | D(強制電報體輸出) | 65% 自稱 → 中立 38% | 🔴 自測 | 🟢 中立測「答案相同」;但 terse 工作負載可能反增 | — |
 | ooples token-optimizer-mcp | B/D | 95%+ 自稱 → 中立 23% | 🔴 零方法論 | 🟡 未評測 | — |
-| RTK | D(壓噪音輸出) | 60~90% 自稱 → 中立 0% | 🔴 自測 | 🟢 只壓噪音、風險低 | — |
+| RTK | D(壓噪音輸出) | 60\~90% 自稱 → 中立 0% | 🔴 自測 | 🟢 只壓噪音、風險低 | — |
 | code-review-graph | B(圖檢索) | 中立 5%(小 repo 反而 0.7x 變貴) | 🔴 | 🟡 未評測 | — |
-| 其他(claude-mem、Headroom 等) | C/D | 10x、~50%(自稱) | 🔴 自測 | 🟡 | 有:claude-mem #618 token 膨脹 |
+| 其他(claude-mem、Headroom 等) | C/D | 10x、\~50%(自稱) | 🔴 自測 | 🟡 | 有:claude-mem #618 token 膨脹 |
 
 ---
 
@@ -106,7 +106,7 @@
 
 - **Serena MCP**(26.5k★):以 LSP(Language Server Protocol,語言伺服器協定,IDE 用來取得符號/定義/引用的標準介面)做符號級檢索,工具用符號名路徑(`MyClass/my_method`)取代整檔讀取。
   - 程式碼:`FindSymbolTool`(`src/serena/tools/symbol_tools.py:132`,參數 `include_body` 註明 "Use judiciously")、`GetSymbolsOverviewTool`(`:36`)、`ReplaceSymbolBodyTool`(`:571`)。
-  - **官方自家 eval 的真實例子**:`get_symbols_overview` 一次呼叫回 ~2.5KB JSON vs Grep ~3KB;官方原話節省幅度是 *"saves ~1 call and some context window tokens per navigation"* —— 遠小於社群流傳的「省 70%」(該 70% 查無出處)。
+  - **官方自家 eval 的真實例子**:`get_symbols_overview` 一次呼叫回 \~2.5KB JSON vs Grep \~3KB;官方原話節省幅度是 *"saves \~1 call and some context window tokens per navigation"* —— 遠小於社群流傳的「省 70%」(該 70% 查無出處)。
 - **claude-context**(Zilliz,12.1k★):AST-aware 切塊 → embedding → Milvus 向量庫 → 混合檢索。
   - **唯一「原則上可重現」的 vendor 量測**(repo `evaluation/README.md`):30 題 SWE-bench Verified 檢索子任務、GPT-4o-mini,tokens 73,373 → 44,449(**−39.4%**)、F1(精確率與召回率的調和平均,越高代表找對檔案的能力越好)0.40 vs 0.40 持平。這就是行銷句「Cut Token Waste by 40%」的全部實驗基礎。
   - 弱點:n=30、限定 2-file 改動、用最受檢索恩惠的弱模型、只測 file localization(F1=0.40 表示兩組都過半機率找錯檔)。
@@ -123,7 +123,7 @@
 ### ④ Context 中介層 / 長期記憶
 
 - **mem0**(arXiv 2504.19413):跨 session 抽取重點事實進向量庫,取代重播全部對話史。宣稱 "saves more than 90% token cost"。
-  - **口徑陷阱**:>90% 是 vs「每次重播 16k~26k token 全史」這個 baseline —— 省 token 是機制上保送的,爭點全在準確率(見〈使用者實證〉)。
+  - **口徑陷阱**:>90% 是 vs「每次重播 16k\~26k token 全史」這個 baseline —— 省 token 是機制上保送的,爭點全在準確率(見〈使用者實證〉)。
 - **SuperClaude**(23.6k★):把 markdown 指令檔注入 context 的「行為框架」。v1 README 宣稱 "70% reduction",現版改口 "30-50% fewer tokens" —— **兩代皆零方法論**。
 - **Anthropic 官方**:context editing + memory tool(宣稱 84% @ 100-turn web search)、Tool Search Tool(85% 省 input 側 tool definitions)。數字全部 internal、無獨立重現,但機制透明。
 
@@ -180,12 +180,12 @@
 
 ### 附帶:Claude Code /compact 是所有人比較的 baseline,自身即最大量負面實證
 
-- **#10006**:「每次 auto-compact,它丟掉每一個細節」。**#13919**:skills 在 compaction 後全失效,任務時間從「~1 小時」變「5-6+ 小時」。工程師實測:「compaction 後明顯變笨,不知道自己剛在看哪些檔案」。
+- **#10006**:「每次 auto-compact,它丟掉每一個細節」。**#13919**:skills 在 compaction 後全失效,任務時間從「\~1 小時」變「5-6+ 小時」。工程師實測:「compaction 後明顯變笨,不知道自己剛在看哪些檔案」。
 - 分類:CLAUDE.md/skills 不回注是**工程 bug**(現版已部分修復);摘要丟中途決策/檔案清單是**機制性有損壓縮**。
 
 ### 平衡:檢索方向也有正面獨立證據
 
-- **Cursor 官方 A/B**(2025-11):同模型下 semantic search vs grep-only,平均**準確率高 12.5%**(6.5%~23.5%);大型 codebase code retention +2.6%。—— 反駁「檢索必然使 coding agent 變笨」的極端讀法。
+- **Cursor 官方 A/B**(2025-11):同模型下 semantic search vs grep-only,平均**準確率高 12.5%**(6.5%\~23.5%);大型 codebase code retention +2.6%。—— 反駁「檢索必然使 coding agent 變笨」的極端讀法。
 - 但對照 Claude Code 官方立場:「Claude Code 目前不用 RAG(Retrieval-Augmented Generation,檢索增強生成,先向量檢索再把片段餵給模型);我們測下來 agentic search 在 Code 的使用情境優於 RAG」。
 
 ---

--- a/domains/mlops/CodingAgentTokenEfficiency/README.zh-TW.md
+++ b/domains/mlops/CodingAgentTokenEfficiency/README.zh-TW.md
@@ -131,7 +131,7 @@
 
 - **RouteLLM**(arXiv 2406.18665):訓練強/弱模型路由器,簡單任務派便宜模型。宣稱「85% 省費用 + 保 95% GPT-4 能力」,但**只測 MT Bench/MMLU/GSM8K,無 coding**。
 - **claude-code-router**(35.8k★):本地 proxy 把 Claude Code 各類流量路由到便宜模型。自身不宣稱 % 節省。
-- **prompt caching**:省的是**費用不是 token**,且寫入有 1.25×/2× 溢價 —— 低命中率時反而更貴。
+- **prompt caching**:省的是**費用不是 token**,且寫入有 1.25×/2× 溢價 —— 低命中率時反而更貴。**且它與大多數動態省 token 方法在很大程度上相衝突(見〈該不該用〉)。**
 
 ---
 
@@ -156,7 +156,8 @@
   | LongCodeZip(行級) | 89.3% |
   | SWE-Pruner(行級) | 87.3% |
 
-- **誠實邊界**:單輪 8x 極限壓縮時 EM(Exact Match,完全匹配率,輸出與標準答案逐字一致的比例)仍從 40.5 掉到 31.0(有實質退化);僅 Python;單一團隊、零第三方重現。**評級:最值得驗證,但尚不足以放心採用。**
+- **誠實邊界**:單輪 8x 極限壓縮時 EM(Exact Match,完全匹配率,輸出與標準答案逐字一致的比例)仍從 40.5 掉到 31.0(有實質退化);僅 Python;單一團隊、零第三方重現。
+- **評級:很可能是可實際採用的方法、具參考價值。** 它是本次調查中唯一「省得多(−23\~38% token)又不掉能力(成功率反升)」有完整公開數據支撐的方向,機制(行級 task-aware)也站得住腳,值得作為設計參考。之所以還不列 🟢「放心採用」,純粹是外部驗證不足(單一團隊、零重現、僅 Python),不是機制或數據有硬傷 —— 建議先在自己的 codebase 上驗證(closure recipe #15)再導入,而非直接照搬或直接否定。
 
 ---
 
@@ -194,6 +195,8 @@
 
 - **想無腦省又不冒險**:優先用「機制上近無損」的手段 —— targeted/diff edits(Claude 4+ 級模型上格式順從稅可忽略)、噪音工具輸出壓縮(只在輸出髒時有效)、tool-definition 延遲載入、prompt caching(注意 cache-miss 反噬與寫入溢價)。Anthropic 內建的 token-efficient tool use 無需採用動作、已內建。
 - **大 codebase(>20k LoC(lines of code,程式碼行數)級)且願付索引維運成本**:才值得上語意檢索工具;預期理論收益會被索引失同步、MCP 固定開銷部分吃掉。
+- **最值得追的新方向**:SWE-Pruner 型的**行級 task-aware 剪枝**很可能是可用且值得參考的方法 —— 唯一「省得多又不掉能力」有完整公開數據者。導入前先自架 skimmer + 在自己 codebase 用 `ccusage` 實測(closure recipe #15),但不必因為「preprint、單一團隊」就直接排除。
+- **⚠️ prompt caching 與動態省 token 方法在很大程度上相衝突,別無腦疊用**:prompt caching 靠「prompt 前綴逐位元組穩定、只在尾端 append」才能吃 0.1x 的 cache-read 折扣;但大多數動態縮 context 的方法(LLMLingua 壓縮、SWE-Pruner 剪枝、Anthropic context editing 清除舊 tool call、記憶/摘要改寫)**每輪都會改動前綴**,一改就讓該點之後的 cache 全部失效 → 退回全價 miss + 1.25×/2× 寫入溢價,兩者疊用可能比各自單用還貴。兩種策略方向相反:caching 要「穩定、只增不改」的 context,積極剪枝要「邊改邊縮」。依成本結構二選一 —— 成本主要來自重複的穩定長前綴就選 caching,來自無上限成長的 context 就選剪枝。
 - **絕不要**:把 token 級 perplexity 剪枝(LLMLingua 型)用在 coding;把 2024 式分類器路由的 85%/95% 宣稱外推到 agentic coding。
 - **通則**:分母不明的百分比不可比。引用任何「省 X%」前,先問**量什麼(input/output/費用/單一子任務)、什麼工作負載、baseline 是誰**。
 


### PR DESCRIPTION
Follow-up to the merged token-efficiency survey note. Two parts:

## 1. Rendering fix — escape tilde ranges
Unescaped `~` in numeric ranges (`20~40%`, `60~95%`, …) is parsed as **strikethrough** by GitHub Flavored Markdown when two appear on the same line. Escaped all range tildes as `\~` in both `README.md` and `README.zh-TW.md`. No tilde was inside a code span.

## 2. Content — two substantive additions (per reviewer feedback)
- **SWE-Pruner reframed**: from "most worth verifying" to **"very likely a genuinely adoptable method with reference value"**. The only direction with full public data behind "saves a lot without losing capability"; the caveat is insufficient external validation (single-team, zero replication, Python-only), *not* a flaw in the mechanism or data.
- **prompt caching conflict added**: a prominent warning that prompt caching **largely conflicts** with dynamic token-saving methods. Caching only earns the 0.1x cache-read discount with a byte-stable, append-only prefix; pruning/compression/context-editing/memory-rewriting mutate the prefix every turn and invalidate the cache from that point on, so stacking them can cost *more* than either alone. Guidance: pick one by cost structure.

Both content changes mirrored across EN + zh-TW. Section/table counts stay aligned (10/10, 38/38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pb2m3f3qKpLcfpR3w2hBe
