### PR TITLE
docs: add language model deployment and vLLM performance notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@
 | [domains](./domains/) | The interesting paper of different domains |
 | [tips](./tips) | Some tips for data science |
 | [tools](./tools/) | Some tools for data science |
+| [mlops](./mlops/) | Notes on model deployment and ML operations |

--- a/domains/utils/transformer-family/flash_attention/README.md
+++ b/domains/utils/transformer-family/flash_attention/README.md
@@ -1,7 +1,7 @@
 | Property  | Data |
 |-|-|
 | Created | 2026-01-23 |
-| Updated | 2026-01-23 |
+| Updated | 2026-08-11 |
 | Author | @Aiden |
 | Tags | #study #optimization #attention |
 
@@ -26,7 +26,7 @@ FlashAttention 是由 Tri Dao 等人於 2022 年提出的一種 **IO-aware** 的
 
 ## 動機：為什麼需要 FlashAttention？
 
-標準的 Self-Attention 具有 $O(N^2)$ 的時間和空間複雜度，其中 $N$ 是序列長度。當序列長度增加時：
+Naive Self-Attention 具有 $O(N^2)$ 的計算量與中間張量空間，其中 $N$ 是序列長度。下表只計算**單一 attention head 的一張 FP16 score matrix**，不代表模型的總 VRAM：
 
 | 序列長度 | 注意力矩陣大小 | 記憶體需求 (FP16) |
 |---------|--------------|------------------|
@@ -43,51 +43,14 @@ FlashAttention 是由 Tri Dao 等人於 2022 年提出的一種 **IO-aware** 的
 ---
 
 ## GPU 記憶體層次結構
-想像 GPU 是一間工廠：
-- **SRAM（Shared Memory）** = 工人手邊的工作台
-  - 容量小（約 192KB），但存取超快（~19 TB/s）
-  - 工人可以直接在上面操作，不用走動
-- **HBM（Global Memory）** = 工廠的大倉庫
-  - 容量大（40-80 GB），但存取較慢（~2 TB/s）
-  - 每次要資料都要走去倉庫搬，很花時間
+想像 GPU 是一間工廠：registers 與 shared memory 是運算單元附近、容量小但快速的
+工作區；HBM/global memory 是容量大但資料搬運成本較高的倉庫。實際容量與頻寬取決
+於 GPU 世代和型號，因此不應把某張 GPU 的數字當成 FlashAttention 的固定規格。
 
-**關鍵問題**：傳統 Attention 會產生超大的中間結果（$N \times N$ 矩陣），工作台放不下，只好存到倉庫。但每次存取倉庫都很慢，成為效能瓶頸。
-
-**FlashAttention 的解法**：把計算切成小塊，確保每一塊都能在工作台上完成，永遠不用跑倉庫。
-
-理解 FlashAttention 的關鍵在於理解 GPU 的記憶體層次結構：
-
-```
-┌─────────────────────────────────────────────────────┐
-│                    GPU Architecture                  │
-├─────────────────────────────────────────────────────┤
-│                                                      │
-│  ┌──────────────────────────────────────────────┐   │
-│  │              SRAM (On-chip)                   │   │
-│  │  ┌────────────────────────────────────────┐  │   │
-│  │  │     Registers: ~20KB per SM            │  │   │
-│  │  │     Bandwidth: ~19 TB/s                │  │   │
-│  │  └────────────────────────────────────────┘  │   │
-│  │  ┌────────────────────────────────────────┐  │   │
-│  │  │     Shared Memory: 192KB per SM        │  │   │
-│  │  │     Bandwidth: ~19 TB/s                │  │   │
-│  │  └────────────────────────────────────────┘  │   │
-│  └──────────────────────────────────────────────┘   │
-│                         ▲                            │
-│                         │ ~10x faster                │
-│                         ▼                            │
-│  ┌──────────────────────────────────────────────┐   │
-│  │              HBM (Off-chip)                   │   │
-│  │  ┌────────────────────────────────────────┐  │   │
-│  │  │     Global Memory: 40-80 GB            │  │   │
-│  │  │     Bandwidth: ~2 TB/s (A100)          │  │   │
-│  │  └────────────────────────────────────────┘  │   │
-│  └──────────────────────────────────────────────┘   │
-│                                                      │
-└─────────────────────────────────────────────────────┘
-```
-
-**關鍵觀察**：SRAM 的存取速度比 HBM 快約 **10 倍**，但容量小約 **1000 倍**。
+Naive Attention 會產生 $N \times N$ scores/probabilities，並在不同 kernels 之間
+寫入、讀回 HBM。FlashAttention 的解法是把 Q、K、V 分塊載入 on-chip memory，
+用 online softmax 累積結果，避免把完整的二次方中間矩陣寫入 HBM。Q、K、V 仍需
+從 HBM 載入，最終 output 也要寫回；省掉的是大量中間資料搬運，而不是完全避開 HBM。
 
 ---
 
@@ -131,7 +94,8 @@ def standard_attention(Q, K, V):
 
 ## FlashAttention 核心原理
 
-FlashAttention 的核心思想是 **在 SRAM 中完成所有計算**，避免將 $N \times N$ 的中間矩陣寫入 HBM。
+FlashAttention 的核心思想是讓每個 tile 的主要運算與 softmax statistics 留在
+on-chip memory，避免將完整 $N \times N$ 中間矩陣寫入 HBM。
 
 ### 一句話總結
 
@@ -224,12 +188,15 @@ $$
 
 ### Causal Masking 的 Block-wise 優化
 
-對於 GPT 這類 Decoder-only 模型，需要使用 Causal Mask（遮蔽掉未來的 token）。在標準 Attention 中，即使被 Mask 掉的位置（右上三角矩陣）仍會參與運算，最後再乘上 0。
+對於 GPT 這類 Decoder-only 模型，需要使用 Causal Mask（遮蔽未來 token）。
+Naive dense 實作可能先計算右上三角區域再套 mask；其他 fused／triangular kernels
+也可能跳過這些工作，所以這不是所有「標準 Attention」實作的必然行為。
 
 FlashAttention 的 Tiling 策略帶來了一個額外優勢：**直接跳過無效的 Block**。
 
 - 因為是分塊計算，如果某個 Block 完全落在 Mask 區域內（例如 $Q$ 的時間步小於 $K$ 的時間步），該 Block **完全不需要讀取和計算**。
-- 這使得 Causal Attention 的計算量在 FlashAttention 中真正減半，進一步提升了效率。
+- 對完整的方形 causal attention，跳過整個被遮蔽的 tiles 可省去接近一半的 score
+  計算；邊界 tiles、kernel 排程與非方形 Q/K 長度會使實際加速不同。
 
 ---
 
@@ -350,16 +317,18 @@ $$
 
 ### 記憶體需求對比
 
-| 方法 | 前向儲存 | 總記憶體 |
+| 方法 | Attention 額外中間儲存 | 包含 Q/K/V/O 的量級 |
 |-----|---------|---------|
-| 標準 Attention | $O(N^2)$ | $O(N^2)$ |
-| FlashAttention | $O(N)$ | $O(N)$ |
+| Naive Attention | $O(N^2)$ | $O(N^2 + Nd)$ |
+| FlashAttention | $O(N)$ softmax statistics | $O(Nd)$ |
 
 ---
 
 ## FlashAttention-2 改進
 
-FlashAttention-2 在原版基礎上進行了多項優化，將 GPU 利用率從 **25-40%** 提升到 **50-73%**。
+FlashAttention-2 論文在其 A100 kernel benchmarks 中，將相對 theoretical maximum
+FLOPs/s 的效率由 FlashAttention 的 **25～40%** 提升至 **50～73%**。這不是整張
+GPU 的通用 utilization 指標，也不是任意模型的端到端提升。
 
 ### 主要改進
 
@@ -409,35 +378,6 @@ GPU 的工人分成小組（warp，32 個 thread 一組），同組的工人必�
 
 ---
 
-### 改進 4：迴圈順序優化
-處理 Q、K、V 三個矩陣時，迴圈的順序會影響效能。
-
-**FlashAttention-1 的做法**：外層迴圈遍歷 K, V blocks
-- 對於每個 K, V block，需要把所有 Q blocks 的結果都更新一遍
-- 這意味著 output (O) 矩陣要被反覆讀取和寫入 HBM
-
-**FlashAttention-2 的做法**：外層迴圈遍歷 Q blocks
-- 對於每個 Q block，遍歷所有 K, V blocks 來計算完整的 attention
-- 計算完成後，O 只需要寫入 HBM 一次
-
-這就像填問卷：與其每個題目都讓所有人輪流填一點，不如讓每個人一次把整份問卷填完再交——減少了問卷來回傳遞的次數。
-
-```python
-# FlashAttention-2: Q 在外層
-for i in range(num_Q_blocks):
-    load Q_i to SRAM
-    for j in range(num_KV_blocks):
-        load K_j, V_j to SRAM
-        compute attention for Q_i with K_j, V_j
-    write O_i to HBM  # 每個 Q block 的結果只寫一次
-```
-
-這種順序的優勢：
-- Q 的每個 block 只需寫入 HBM 一次
-- 更好的記憶體存取模式
-
----
-
 ## FlashAttention-3 改進
 
 FlashAttention-3 針對 NVIDIA Hopper GPU (H100) 進行了深度優化。
@@ -445,36 +385,27 @@ FlashAttention-3 針對 NVIDIA Hopper GPU (H100) 進行了深度優化。
 ### 主要特性
 
 #### 特性 1：WGMMA (Warpgroup Matrix Multiply-Accumulate)
-H100 GPU 引入了新的矩陣乘法指令 WGMMA，比舊的 WMMA 指令更強大。
-
-**傳統方式**：CPU 發指令 → GPU 執行 → CPU 等結果 → 發下一個指令（同步執行）
-
-**WGMMA 的改進**：CPU 發完指令就去做別的事，GPU 自己慢慢算，算完會通知（非同步執行）。
-WGMMA (Warpgroup Matrix Multiply-Accumulate) 是 Hopper 架構引入的新指令，它在 **Warpgroup (128 threads)** 層級運作，比傳統的 Warp (32 threads) 層級更有效率。且它支援 Tensor Memory Accelerator (TMA) 的非同步數據搬運，讓計算單元不用停下來等資料。
-
-這就像寄快遞：與其站在郵局等包裹寄到才離開，不如寄完就走，快遞到了會有簡訊通知。
+Hopper 引入 warpgroup-level asynchronous matrix multiply instructions。FlashAttention-3
+利用 WGMMA 與 Tensor Memory Accelerator（TMA），讓 GPU warpgroups 的矩陣運算
+和 global/shared memory 資料搬運重疊。這是 GPU kernel 內部的非同步 pipeline，
+不是「CPU 發一條指令後等待 GPU」的流程。
 
 ---
 
 #### 特性 2：Ping-pong Scheduling
 
-GPU 中的「warpgroup」是一組一起工作的 threads。FlashAttention-3 使用兩個 warpgroup 像打乒乓球一樣交替工作：
-
-- **Warpgroup A**：正在計算矩陣乘法
-- **Warpgroup B**：同時在從記憶體載入下一批資料
-
-當 A 算完需要新資料時，B 剛好載入完成，兩者交換角色。這樣記憶體延遲就被「藏起來」了，GPU 永遠有事做。
-
-這就像餐廳的雙廚房模式：一個廚房在煮菜時，另一個廚房在備料。菜上桌後兩邊角色互換，客人永遠不用等。
+Kernel 以 warp specialization 分配 producer 與 consumer 工作，並讓 consumer
+warpgroups 交錯執行 matmul 和 softmax。這可隱藏部分資料搬運與非 matmul 運算
+延遲，但收益取決於 shape、dtype 與硬體，不能理解為 GPU 永遠沒有 idle cycles。
 
 ---
 
 #### 特性 3：FP8 支援
 FP8 是一種只用 8 位元表示的浮點數（相比 FP16 的 16 位元或 FP32 的 32 位元）。
 
-**優勢**：
-- 計算量減半：同樣的硬體可以處理兩倍的數據
-- 記憶體減半：可以處理更長的序列或更大的 batch
+**潛在優勢**：FP8 operand payload 約為 FP16 的一半，且 Hopper Tensor Cores 有
+相應低精度吞吐能力；這不表示 attention 的數學 FLOPs 減半，也不保證端到端速度
+或可用 context 必然翻倍。
 
 **挑戰**：FP8 精度很低，容易造成數值問題
 
@@ -488,28 +419,16 @@ FP8 是一種只用 8 位元表示的浮點數（相比 FP16 的 16 位元或 FP
 ---
 
 #### 特性 4：Incoherent Processing
-傳統的 attention 計算有嚴格的順序依賴：
-1. 先算 $QK^T$
-2. 等算完才能做 softmax
-3. 等 softmax 完才能乘 V
-
-這種「等前一步完成才能開始下一步」的模式叫做「coherent（一致的）」處理，會造成 GPU 資源閒置。
-
-**Incoherent Processing 的做法**：
-- 把 softmax 的計算和矩陣乘法「解耦」
-- 讓不同的硬體單元可以同時工作
-- 即使前一步沒完全做完，只要有部分結果就開始做下一步
-
-這就像流水線作業：不用等整批產品都檢驗完才開始包裝，檢驗完一個就包一個。
+這裡的 incoherent processing 不是取消 $QK^T \rightarrow softmax \rightarrow PV$
+的資料依賴。FlashAttention-3 對輸入套用隨機正交變換，使 outliers 分散後再做
+FP8 block quantization；正交變換保持 attention 所需的數學關係，目的是降低低精度
+量化誤差。計算與資料搬運的重疊則屬於前述 asynchrony／warp specialization。
 
 ### 效能提升
 
-在 H100 上的效能對比：
-
-| 版本 | 相對效能 | 達到的 TFLOPS |
-|-----|---------|--------------|
-| FlashAttention-2 | 1.0x | ~400 TFLOPS |
-| FlashAttention-3 | 1.5-2.0x | ~600-750 TFLOPS |
+FlashAttention-3 論文在其 H100 測試設定中，報告 FP16 相對 FlashAttention-2
+有 1.5～2.0 倍速度提升，最高約 740 TFLOPs/s；FP8 接近 1.2 PFLOPs/s。這是指定
+GPU、kernel shapes 與 benchmark 的結果，不應直接外推成任意模型的端到端加速。
 
 ---
 
@@ -565,6 +484,7 @@ output = memory_efficient_attention(q, k, v)
 ```python
 import torch
 import torch.nn.functional as F
+from torch.nn.attention import SDPBackend, sdpa_kernel
 
 # PyTorch 2.0+ 內建 scaled_dot_product_attention
 # 會自動選擇最佳後端 (包括 FlashAttention)
@@ -573,12 +493,8 @@ q = torch.randn(2, 32, 2048, 64, dtype=torch.float16, device='cuda')
 k = torch.randn(2, 32, 2048, 64, dtype=torch.float16, device='cuda')
 v = torch.randn(2, 32, 2048, 64, dtype=torch.float16, device='cuda')
 
-# 使用 SDPA (自動選擇 FlashAttention 如果可用)
-with torch.backends.cuda.sdp_kernel(
-    enable_flash=True,
-    enable_math=False,
-    enable_mem_efficient=False
-):
+# 僅允許 FlashAttention backend；不相容時會直接報錯，適合驗證 backend。
+with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
     output = F.scaled_dot_product_attention(q, k, v, is_causal=True)
 ```
 
@@ -593,37 +509,32 @@ with torch.backends.cuda.sdp_kernel(
 | 計算 FLOPs | $O(N^2 d)$ | $O(N^2 d)$ |
 | HBM 存取 | $O(N^2 + Nd)$ | $O(N^2 d^2 M^{-1})$ |
 
-當 $M = \Theta(Nd)$ 時，FlashAttention 的 HBM 存取為 $O(N^2 d / M) = O(N)$。
+當 $M = \Theta(Nd)$ 時，上式化簡為 $O(Nd)$；若把 head dimension $d$ 視為常數，
+才可簡寫成對序列長度 $N$ 的線性 I/O。
 
 ### 記憶體複雜度
 
-| 方法 | 中間儲存 | 總記憶體 |
+| 方法 | Attention 額外中間儲存 | 包含 Q/K/V/O 的量級 |
 |-----|---------|---------|
-| 標準 Attention | $O(N^2)$ | $O(N^2)$ |
-| FlashAttention | $O(N)$ | $O(N)$ |
+| Naive Attention | $O(N^2)$ | $O(N^2 + Nd)$ |
+| FlashAttention | $O(N)$ softmax statistics | $O(Nd)$ |
 
-### 實際效能數據
-
-在 A100 (40GB) 上的典型加速比：
-
-| 序列長度 | 加速比 (vs PyTorch) | 記憶體節省 |
-|---------|-------------------|-----------|
-| 512 | 2-3x | 5-20x |
-| 2K | 3-5x | 10-20x |
-| 8K | 4-7x | 10-20x |
-| 16K | 5-10x | 10-20x |
+實際加速不應套用固定倍數。應在相同 dtype、shape、causal mask、dropout、warmup
+與同步方式下，比較 kernel latency、peak allocated memory 與端到端模型吞吐；短序列
+或不相容 shape 可能讓 launch／dispatch overhead 主導。
 
 ---
 
 ## 限制與注意事項
 
 1. **硬體要求**
-   - 需要 NVIDIA GPU (Turing 架構及以上)
-   - 最佳效能在 Ampere (A100) 和 Hopper (H100)
+   - 支援範圍取決於套件與版本。官方 FlashAttention-2 CUDA 實作目前主要支援
+     Ampere、Ada、Hopper；Turing 使用另一個功能子集 repo，另有 ROCm backends。
+   - FlashAttention-3 針對 Hopper；不能把 FA3 的 H100 結果外推到其他 GPU。
 
 2. **精度要求**
-   - 主要支援 FP16 和 BF16
-   - FP32 需要特殊處理
+   - 官方 CUDA FlashAttention-2 主要支援 FP16/BF16；FA3 另有 Hopper FP8 forward。
+   - Backend 支援不等於模型品質不變，低精度路徑仍需數值驗證。
 
 3. **注意力變體支援**
    - 標準 attention ✓
@@ -631,8 +542,8 @@ with torch.backends.cuda.sdp_kernel(
    - 某些複雜的 attention mask 可能不支援
 
 4. **Head dimension 限制**
-   - 通常限制在 32, 64, 128, 256
-   - 非標準 head dim 可能無法使用
+   - 官方 CUDA FlashAttention-2 目前支援 head dimension 至 256；其他 backend、
+     backward、dropout 與 GPU 組合可能有不同限制，應查當下版本 feature matrix。
 
 ---
 
@@ -641,5 +552,8 @@ with torch.backends.cuda.sdp_kernel(
 1. [FlashAttention: Fast and Memory-Efficient Exact Attention with IO-Awareness](https://arxiv.org/abs/2205.14135)
 2. [FlashAttention-2: Faster Attention with Better Parallelism and Work Partitioning](https://arxiv.org/abs/2307.08691)
 3. [FlashAttention-3: Fast and Accurate Attention with Asynchrony and Low-precision](https://arxiv.org/abs/2407.08608)
-4. [Online normalizer calculation for softmax](https://arxiv.org/abs/1805.02867)
-5. [GitHub: flash-attention](https://github.com/Dao-AILab/flash-attention)
+4. [FlashAttention official implementation and support matrix](https://github.com/Dao-AILab/flash-attention)
+
+## 延伸閱讀
+
+- [FlashAttention 與 PagedAttention：算子最佳化和 KV cache 管理](./flash-attn-vs-paged-attn.md)

--- a/domains/utils/transformer-family/flash_attention/flash-attn-vs-paged-attn.md
+++ b/domains/utils/transformer-family/flash_attention/flash-attn-vs-paged-attn.md
@@ -1,68 +1,92 @@
-# Flash Attention vs. Paged Attention 架構解析
+# FlashAttention 與 PagedAttention：算子最佳化和 KV cache 管理
 
+FlashAttention 與 PagedAttention 經常一起出現在 LLM serving 系統，卻不是互相
+替代的技術。FlashAttention 主要減少一次 attention 計算在 GPU 記憶體階層間的
+資料搬運；PagedAttention 則讓長度動態變化的 KV cache 能以固定大小 blocks
+配置、共享與回收。
 
+## 核心差異
 
+| 面向 | FlashAttention | PagedAttention |
+|---|---|---|
+| 主要問題 | Attention kernel 的 HBM I/O 與中間張量 | Serving 時 KV cache 的動態配置、碎片與共享 |
+| 抽象層級 | GPU attention algorithm／kernel | KV block manager + 能讀取 paged KV 的 attention algorithm |
+| 主要資料 | 當次計算的 Q、K、V、softmax statistics 與 output | 跨 decoding steps 保留的 K/V tensors |
+| 核心方法 | Tiling、online softmax、kernel fusion，避免物化完整 attention matrix | Logical blocks、physical blocks 與 block table；按需配置 physical blocks |
+| 直接收益 | 降低記憶體流量與 attention 暫存空間，改善 kernel latency | 降低 KV cache 浪費、提高可容納 sequences 數，支援 prefix／beam sharing |
+| 仍無法消除 | Attention 的數學計算量；Q/K/V 與 output 仍需讀寫 HBM | 最後一個 block 的內部碎片、block metadata 與 scheduler 成本 |
+| 常見受益階段 | 長序列 prefill／training；decode 也需相容的最佳化 kernel | 自迴歸 serving 的 prefill 與 decode，decode 階段持續成長最明顯 |
 
+## FlashAttention：避免物化二次方中間矩陣
 
-## 一、 核心對比與技術定位
+Naive attention 會把 $S = QK^T$ 與 softmax probabilities 寫入 HBM。對序列長度
+$N$，這些中間矩陣具有 $O(N^2)$ 空間需求。FlashAttention 將 Q、K、V 分塊，
+在 on-chip memory 中以 online softmax 累積結果，不把完整 $N \times N$ 矩陣
+寫回 HBM。
 
-| 對比維度 | Flash Attention (運算加速/IO最佳化) | Paged Attention (記憶體管理) |
-| :--- | :--- | :--- |
-| **解決痛點** | GPU 記憶體頻寬瓶頸 (Memory Wall / IO-Bound) | KV Cache 顯存碎片化與利用率低下 |
-| **核心目標** | 讓運算「跑得更快」 (降低延遲，提升計算極限) | 讓顯存「裝得下更多」 (提升 Batch Size 與吞吐量) |
-| **作用焦點** | Attention 矩陣機制的底層算子最佳化 (Kernel 層級)| LLM 生成過程中的上下文 (KV Cache) 分配機制 |
-| **發揮優勢階段**| Prefill (預填充/編碼) 階段效率極高 | Decode (解碼/生成) 階段顯存管線的核心 |
-| **核心技術手段**| Tiling (分塊計算)、Kernel Fusion (算子融合) | OS 分頁機制 (Paging)、Block Table 虛擬映射 |
+它仍然計算精確 attention，計算複雜度仍是 $O(N^2d)$；改善的是 I/O 複雜度與
+額外儲存，不是把 dense attention 變成線性時間。Q、K、V 仍要從 HBM 載入，
+output 也要寫回 HBM，因此「完全不碰 HBM」並不正確。
 
----
+## PagedAttention：按 block 管理 KV cache
 
-## 二、 Flash Attention：突破讀寫瓶頸 (IO-Aware)
+自迴歸推論需要保存每一層過去 tokens 的 K/V。每個 request 的實際長度不同，
+而且在 decode 過程中逐 token 成長；若為最大長度預留連續區域，容易造成過度
+預留與碎片。
 
-**核心概念**：把「草稿」留在腦袋裡算完，不寫在紙上。避免 GPU 運算單元（SRAM）頻繁去慢速的大容量顯存（HBM）讀寫短暫的過程數據。
+PagedAttention 把 request 的 KV cache 表示為 logical blocks，並透過 block table
+映射到不必連續的 physical blocks：
 
-1. **算子融合與分塊計算 (Tiling)**：
-   傳統 Attention 會將龐大的 $N \times N$ 注意力分數矩陣物化（Materialize）並寫入 HBM，再讀出來做 Softmax。Flash Attention 將 $Q, K, V$ 切成小塊 (Blocks) 載入高速但極小的 **SRAM**，在內部直接完成所有運算，**只將最終結果寫回 HBM**。
-2. **記憶體複雜度降維**：
-   將 Attention 的顯存佔用從暴衝的 $O(N^2)$ 降到了線性 $O(N)$，同時極大地減少了 HBM 的讀寫次數 (Memory Accesses)，有效解決 IO-Bound 瓶頸。
+1. Prefill 根據已處理的 prompt tokens 配置所需 blocks。
+2. Decode 填入最後一個 block；容量不足時再取得新的 physical block。
+3. Request 完成後，physical blocks 回到 free pool。
+4. 多個 sequences 共享相同 prompt 時，可透過 reference counting 與
+   copy-on-write 共享既有 blocks。
 
----
+這個設計把單一 sequence 的 block-level 內部浪費限制在最後一個未填滿 block，
+但不代表顯存可以達到 100% 利用率。模型權重、activations、CUDA graphs、allocator
+與 kernel workspaces 都需要 VRAM；block size 也在 kernel 效率、metadata 與內部
+碎片之間形成 trade-off。原始 vLLM 論文報告的低浪費與吞吐提升是其測試設定下
+的實驗結果，不是所有模型與 workload 的固定保證。
 
-## 三、 Paged Attention：解放顯存碎片化
+## 兩者如何一起工作
 
-**核心概念**：借鑑作業系統的「虛擬記憶體分頁」，動態為無法預知長度的對話分配空間。
+Serving engine 可以同時使用 paged KV cache 與 FlashAttention-family kernel：
 
-1. **痛點：未知的生成長度**：
-   傳統 LLM 生成文字時，需為每筆請求預先分配「最大可能長度」的連續顯存（KV Cache）。這會產生巨大的內部與外部碎片，導致實際顯存利用率通常不到 30%。
-2. **非連續存儲 (Paging Mechanisms)**：
-   將 KV Cache 切分成固定大小的單位 **Blocks**（例如每個 Block 存 16 個 Token 的 K 與 V）。
-3. **邏輯與物理映射 (Block Table)**：
-   系統在 CPU 記憶體中維護一張 **Block Table（類似 OS 的分頁表）**，負責記錄 Key-Value 映射：將對話的「邏輯 Block 編號」對應到 GPU 顯存中的「物理 Block 索引」。**注意：表內只存指標，真正的張量數據（KV Cache）皆存放於顯存中。**
-   * **分配時機**：在 Prefill（預填充）階段，如果 Prompt 有 32 個 Token，系統會**一次性**分配 2 個 Block（假設 1 Block = 16 Token）並記錄在 Block Table 中。進入 Decode（生成）階段後，每生成一個新 Token 就塞進最後一個 Block，<mark>直到最後一個 Block 塞滿了，系統才會去顯存池再要一個新的 Block</mark>。最糟的情況也只會浪費「最後一個 Block 沒裝滿」的零頭空格（浪費 < 4%）。
-   * **註銷時機（釋放與回收）**：當該筆 Request 徹底結束時（例如模型生成了 `<EOS>` 結束符號、達到長度上限，或客戶端主動中斷），vLLM 的調度器 (Scheduler) 就會將這張 Block Table 裡所有記錄的「物理 Block 指標」，歸還給 GPU 的「空閒池 (Free Pool)」。完成指標釋放後，這張專屬該 Request 的 Block Table 就會從 CPU 記憶體中被註銷刪除。
-4. **極致的顯存利用率（消滅碎片化）**：
-   * **消滅內部碎片 (Internal Fragmentation)**：傳統為了防範生成過長，必須一開始就為每個 Request 預先切出一大塊（例如 2048 token）的連續顯存。如果最後只生成了 100 個 token，剩下 1948 的空間就被白白鎖死（這就是巨大浪費）。有了 Block 和 Block Table 後，變成**用多少拿多少**。
-   * **消滅外部碎片 (External Fragmentation)**：傳統的連續分配，會在顯存池中留下許多不規則大小的「空隙」（像是裝箱時剩下的畸零空間），這些空隙太小放不下新 Request。但在 Paged Attention 中，所有的 Block 都是**一模一樣大**的標準規格。任何一個被釋放的 Block，都能立刻被其他 Request 拿去拼圖，顯存空間可以被 100% 嚴密榨乾。
-
----
-
-## 四、 兩者在 vLLM 中的協作 (The Big Picture)
-
-在先進的 LLM 推理框架（如 vLLM）中，這兩者並非競爭，而是**上下層的緊密結合**：
-
-* **資源調度 (Paged Attention)**：
-  負責「資源調度」。框架會決定每個 Request 的 KV Cache 該放在物理顯存的哪些**不連續 Blocks** 中，並維護 Block Table。
-* **運算加速 (Flash Attention / Paged-Flash Attention)**：
-  負責「極速運算」。當 Decode 階段需要計算 Attention 時，會拿著 Block Table 把這些分散的 KV Cache 讀入 SRAM，並套用 Flash Attention 的 Tiling 技巧快速算出結果。
-
----
-
-## 五、 如何在日誌中確認生效
-
-在啟動 vLLM 或其他推理引擎時，可透過日誌觀察後端算子的調用情況。若硬體支援，系統會自動選用最佳算子組合：
-
-```bash
-# 查看啟動日誌中是否包含以下字樣
-INFO: vLLM is using PagedAttention.
-INFO: Using FlashAttention-2 backend.
-# 此時代表你的框架正在完美運作：PA 管理顯存 + FA 加速算子
+```text
+request scheduler
+      │
+      ├─ KV block manager ── logical blocks → physical KV blocks
+      │
+      └─ attention backend ── block table + Q/K/V → attention output
 ```
+
+「Paged」描述 KV 的佈局與生命週期；「Flash」描述 attention 計算如何降低 I/O。
+實際 backend 必須同時支援模型 dtype、head size、KV dtype、block size、GPU compute
+capability 與所需 attention pattern。框架能管理 paged KV，不代表任意
+FlashAttention build 都能讀取該佈局。
+
+以 vLLM 為例，backend 會依硬體與模型配置自動驗證和選擇；目前官方 feature
+matrix 同時列出 FlashAttention、FlashInfer、Triton Attention 等選項，而且不同
+GPU 世代的優先序不同。因此不要依賴手寫的假想 log 字串判定功能已啟用，應：
+
+1. 固定 vLLM image/version 與啟動參數。
+2. 讀取實際啟動日誌中的 selected attention backend。
+3. 對照該版本的 backend feature matrix。
+4. 用目標 prompt/context/concurrency 實測 TTFT、ITL、throughput、VRAM 與錯誤率。
+
+## 選擇問題時的快速判斷
+
+- 單筆長 prompt 的 attention 很慢或暫存空間過高：先檢查 attention backend、
+  dtype、head dimension 與 FlashAttention 相容性。
+- 高併發或長 context 下 KV cache 接近滿載、發生 preemption：先檢查 cache
+  bytes/token、block 容量、scheduler budget 與 PagedAttention/KV manager metrics。
+- 兩種現象同時存在：分別量測 kernel latency 與 request-level queue/cache 指標，
+  不要把所有改善都歸因於其中一項技術。
+
+## 延伸閱讀
+
+- [FlashAttention 深度解析](./README.md)
+- [FlashAttention paper](https://arxiv.org/abs/2205.14135)
+- [PagedAttention / vLLM paper](https://arxiv.org/abs/2309.06180)
+- [vLLM attention backend feature matrix](https://docs.vllm.ai/en/latest/design/attention_backends/)

--- a/mlops/language-model-deployment/README.md
+++ b/mlops/language-model-deployment/README.md
@@ -1,0 +1,178 @@
+# 語言模型部署筆記：vLLM、llama.cpp 與 TEI 的取捨
+
+> 更新日期：2026-08-11
+
+把模型「跑起來」通常不難；真正困難的是選到與模型格式、硬體容量、API
+負載及維運方式相符的 runtime。框架名氣不能取代相容性驗證：同一個 30B
+模型，可能只有 GGUF 量化檔，也可能只有 AWQ/GPTQ checkpoint；這會直接
+決定部署路線。
+
+這篇筆記整理自一次 32 GB 消費級 NVIDIA GPU 的部署實作。目標模型是
+[`meta-models/Muse-Glimmer-30B`](https://huggingface.co/meta-models/Muse-Glimmer-30B)，
+服務需提供 OpenAI-compatible API，並以可攜、可重建、可回滾的 IaC 管理。
+
+## 先看 artifact，再選 runtime
+
+部署前至少要確認以下四件事：
+
+1. 模型架構是否被 runtime 原生支援，或至少有經過驗證的相容 backend。
+2. 量化格式是 AWQ、GPTQ、GGUF、BitsAndBytes，還是廠商自有格式。
+3. 權重、KV cache、vision encoder 與 speculative drafter 的總記憶體需求。
+4. API 的預期負載是單人互動、固定少量 slots，還是大量非同步請求。
+
+Muse Glimmer 的 BF16 權重約 60 GB，無法直接放進 32 GB VRAM。官方 4-bit
+版本則發布在
+[`Muse-Glimmer-30B-GGUF`](https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF)：
+
+| Artifact | 約略大小 | 用途 |
+|---|---:|---|
+| K-Quant-Dynamic | 19.7 GB | 32 GB GPU 的主要語言模型 |
+| K-Quant-17GB | 16.8 GB | 24 GB GPU 或需要更多記憶體餘裕 |
+| Perception encoder | 1.4 GB | 圖片輸入 |
+| DFlash drafter | 1.6 GB | Speculative decoding |
+
+因此，這不是單純在 vLLM 啟動參數加上 `--quantization` 就能解決的問題；
+官方 4-bit artifact 本身就是為 llama.cpp 準備的 GGUF。
+
+## 三種常見 serving runtime
+
+### vLLM
+
+vLLM 適合已受支援的生成模型，以及對高併發、吞吐量與 GPU 記憶體調度有
+要求的服務。核心優勢包括 PagedAttention、continuous batching、prefix
+caching，以及成熟的 OpenAI-compatible server。請求超過當下可執行容量時，
+scheduler 會保留在等待佇列，並在 token budget 與 KV block 可用時持續併入
+後續 engine step；不是每次湊滿一個固定 batch 才開始。
+
+但「vLLM 支援 GGUF」不代表「vLLM 支援所有 GGUF 模型」。GGUF loader 仍需
+理解模型架構；而且官方文件將 GGUF 支援標示為 experimental、under-optimized。
+截至 2026-08-11，vLLM v0.27.0 與當日 main 都沒有 Muse Glimmer 的原生
+registry entry，官方 supported-model list 也尚未列入此架構。
+
+### llama.cpp
+
+llama.cpp 適合 GGUF、本地或邊緣部署、單 GPU，以及需要可攜二進位與較小
+維運面積的情境。`llama-server` 已支援 OpenAI-compatible chat API、平行
+decoding、continuous batching、multimodal input、function calling、metrics
+與 speculative decoding。
+
+它同樣有 KV cache 與 Flash Attention：
+
+- 每個 processing slot 保存 KV cache，預設會依 prompt 相似度嘗試重用前綴。
+- KV cache 可使用 F16，也可量化為 Q8/Q4；選擇量化 cache 時要確認相應的
+  CUDA Flash Attention kernel，否則可能退回較慢路徑。
+- `--flash-attn on` 可以明確啟用 CUDA Flash Attention。
+- `--parallel N` 決定同時工作的 slots；超出的 request 會 deferred。
+- `--ctx-size` 是 server 總 context，會分配給 slots。例如
+  `--ctx-size 131072 --parallel 4` 代表每個 slot 約 32K tokens，而不是每個
+  request 都有 128K。
+
+llama.cpp 支援 continuous batching，但其 unified KV cache 與 slots 模型不像
+vLLM 的 paged KV block scheduler 那麼適合高併發、多種長度混合的工作負載。
+它的優勢是簡潔與模型相容性，不是全面取代 vLLM 的 production scheduler。
+
+### Text Embeddings Inference（TEI）
+
+TEI 是專門服務 embedding model 的 runtime。它提供 tokenization、動態
+batching、Prometheus metrics 與常見 embedding API；若機器只服務 embedding，
+通常比通用生成框架更聚焦。相對地，它不是用來提供一般 chat completion 的
+小型 LLM runtime。若同一台主機同時規劃 embedding 與生成模型，應先決定是否
+接受兩套 runtime，不能只為了「統一」而忽略各模型的官方量化格式與支援度。
+
+## 通用情境：先按 workload 選框架
+
+先不考慮任何特定模型，llama.cpp 與 vLLM 解決的是部分重疊、但重心不同的
+問題。前者優先處理可攜性、廣泛硬體與 GGUF 生態；後者優先處理 GPU serving
+的吞吐量、動態排程與叢集擴展。
+
+| 決策面向 | llama.cpp | vLLM |
+|---|---|---|
+| 主要目標 | 輕量、本地、邊緣與單機推論 | 高吞吐、多租戶 GPU API serving |
+| 常見模型格式 | GGUF 與 K/I-quants | Hugging Face Safetensors、AWQ、GPTQ、FP8 等 |
+| 硬體範圍 | CPU、Apple Metal、CUDA、ROCm、Vulkan 等 | 以資料中心 GPU/accelerator 為主 |
+| Request scheduling | Slots + continuous batching | Token-level continuous batching + scheduler |
+| KV cache 管理 | Unified KV cache；容量與 slots/context 配置關係直接 | PagedAttention；以 block 動態配置，較能降低碎片 |
+| 高併發與混合長度 | 可服務多使用者，但固定 slots 較容易成為容量邊界 | 通常更擅長大量、長短不一的併發 request |
+| Prefix cache | 依 slot/prompt 相似度重用，也可保存與還原 slot | Block-based prefix caching，較適合共享前綴 workload |
+| 分散式推論 | 支援多 GPU，但不是主要強項 | Tensor/Data/Pipeline/Expert parallel 生態較完整 |
+| OpenAI API | 常用 chat/completions 可用；仍有實作差異 | API 相容性與 production integration 通常較完整 |
+| 維運成本 | Binary/container 輕量，容易攜帶與離線部署 | Python/CUDA stack 較重，但 observability 與擴展工具成熟 |
+| 典型選擇 | 個人助理、edge/offline、單機 GGUF、CPU/GPU 混合 offload | 團隊共用 API、高 QPS、批次推論、多 GPU 服務 |
+
+這張表描述的是設計傾向，不是絕對效能排名。低併發時，模型 kernel 與量化格式
+可能比 scheduler 更影響速度；高併發時，TTFT、inter-token latency、輸入長度
+分佈與 KV cache 壓力又可能比單筆 tokens/s 更重要。最終仍要用實際 workload
+做 concurrency sweep。
+
+## 特定案例：Muse Glimmer 的 llama.cpp 與 vLLM 決策表
+
+將通用決策套用到 Muse Glimmer 後，artifact 與 runtime support 形成更強的
+限制。下表只描述 2026-08-11 當下的 Muse Glimmer 部署情境，不應直接外推到
+其他模型：
+
+| 面向 | llama.cpp | vLLM |
+|---|---|---|
+| Muse Glimmer 支援 | 官方、可直接跑 | 尚未正式支援 |
+| 官方 4-bit | K-Quant GGUF | 沒有 AWQ/GPTQ checkpoint |
+| 單機部署 | 輕量、可攜性高 | Python/CUDA stack 較重 |
+| 高併發排程 | Continuous batching，但以 slots 為主 | PagedAttention、動態排程通常更強 |
+| KV 記憶體利用 | Unified/fixed slot 設計 | Paged KV cache，碎片與高併發管理更佳 |
+| OpenAI API | 支援，但相容性不如 vLLM 完整 | 相容性、metrics、production tooling 較成熟 |
+| 這個模型的成熟度 | 官方針對 RTX 5090 驗證 | 尚未驗證 |
+
+這張 model-specific 表不是一般性的「框架排名」。對 Llama、Qwen 等 vLLM 原生支援且具有
+AWQ/GPTQ checkpoint 的模型，結論可能相反；對 Muse Glimmer，官方 artifact
+與已驗證實作使 llama.cpp 成為較低風險的選擇。
+
+## IaC 應該鎖定什麼
+
+一鍵啟動不能只是一份 `docker-compose.yml`。可重建部署至少應保存：
+
+- 模型 repo、revision、精確檔名與 SHA-256。
+- runtime source tag/commit，或 container manifest digest。
+- GPU architecture、build flags、context、parallel slots、batch 與 KV cache 型別。
+- loopback bind、API authentication、TLS gateway 與來源 allowlist。
+- 健康檢查、未授權 401、模型 discovery、實際 generation smoke test。
+- 切換前驗證與 rollback；新模型未通過 smoke test 時自動恢復舊服務。
+- 權重、Docker/containerd、compile cache 都放在資料碟，不占用系統碟。
+
+浮動 container tag 是常見陷阱。本次實作時，官方 `server-cuda` image 的實際
+build 是 10335，但 Muse Glimmer 至少要求 llama.cpp b10353。若只看到 image
+成功 pull 就停下來，模型會在切換後才拒絕載入。因此部署改為鎖定 b10355
+source commit，自建 CUDA image，並在停掉舊服務前驗證 runtime build number。
+
+API key 也不應出現在 CLI arguments。可優先使用 runtime 提供的 environment
+variable 或唯讀 secret file，避免 command line、process list 或啟動日誌外洩。
+服務本身只監聽 loopback，再由 TLS gateway 暴露必要的 `/v1/` 路由。
+
+## 建議的決策流程
+
+1. 先從官方 model card 找到受支援的 artifact 與推薦 runtime。
+2. 在不占用 GPU 的情況下完成下載、checksum、image build 與設定驗證。
+3. 以預期的 context、slots 與 KV precision 估算記憶體，不以模型檔大小代替
+   runtime VRAM。
+4. 停止舊模型後啟動候選服務；檢查 authentication、API response、GPU allocation
+   與 container health。
+5. 執行 restart recovery，才算完成可維運部署。
+6. 最後再做 concurrency sweep；用吞吐量、TTFT、inter-token latency、p95/p99
+   與錯誤率選擇 slots，而不是只看單筆 tokens/s。
+
+## 結論
+
+如果模型已被 vLLM 原生支援，且目標是多使用者高併發 API，vLLM 通常是較好的
+起點；如果官方只發布 GGUF、部署在單張消費級 GPU，或模型首先在 llama.cpp
+落地，llama.cpp 通常更可靠。純 embedding 節點則值得優先評估 TEI。
+
+框架統一可以降低維運成本，但相容性、可回滾與可驗證性應優先於形式上的統一。
+在 Muse Glimmer 的案例中，採用 llama.cpp 不是因為它普遍優於 vLLM，而是因為
+它是目前唯一有官方 4-bit artifact 與硬體驗證的路線。
+
+## 參考資料
+
+- [Muse Glimmer 30B model card](https://huggingface.co/meta-models/Muse-Glimmer-30B)
+- [Muse Glimmer 30B GGUF model card](https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF)
+- [llama.cpp HTTP server](https://github.com/ggml-org/llama.cpp/blob/master/tools/server/README.md)
+- [llama.cpp feature matrix](https://github.com/ggml-org/llama.cpp/wiki/Feature-matrix)
+- [vLLM supported models](https://docs.vllm.ai/en/latest/models/supported_models/)
+- [vLLM GGUF documentation](https://docs.vllm.ai/en/latest/features/quantization/gguf/)
+- [Text Embeddings Inference](https://github.com/huggingface/text-embeddings-inference)

--- a/mlops/language-model-deployment/README.md
+++ b/mlops/language-model-deployment/README.md
@@ -44,6 +44,11 @@ caching，以及成熟的 OpenAI-compatible server。請求超過當下可執行
 scheduler 會保留在等待佇列，並在 token budget 與 KV block 可用時持續併入
 後續 engine step；不是每次湊滿一個固定 batch 才開始。
 
+PagedAttention 管理 KV cache 的 block 佈局與生命週期，FlashAttention 則最佳化
+attention kernel 的資料搬運；兩者可以在 serving engine 中協作，但不是同一層的
+替代方案。詳細區分見
+[FlashAttention 與 PagedAttention：算子最佳化和 KV cache 管理](../../domains/utils/transformer-family/flash_attention/flash-attn-vs-paged-attn.md)。
+
 但「vLLM 支援 GGUF」不代表「vLLM 支援所有 GGUF 模型」。GGUF loader 仍需
 理解模型架構；而且官方文件將 GGUF 支援標示為 experimental、under-optimized。
 截至 2026-08-11，vLLM v0.27.0 與當日 main 都沒有 Muse Glimmer 的原生

--- a/mlops/vllm-performance-engineering/README.md
+++ b/mlops/vllm-performance-engineering/README.md
@@ -33,6 +33,10 @@ decode，再把長 prefill 切塊塞入剩餘 token budget。因此 `max_num_bat
 是「每次 iteration 最多處理多少 tokens」，`max_num_seqs` 才是「每次 iteration
 最多處理多少 sequences」；兩者都不是 API 同時連線數。
 
+Attention kernel 的 I/O 最佳化與 KV cache 的分頁管理是兩個不同問題；可先閱讀
+[FlashAttention 與 PagedAttention 的架構比較](../../domains/utils/transformer-family/flash_attention/flash-attn-vs-paged-attn.md)，
+再回到本文觀察它們如何影響 scheduler、cache capacity 與 latency。
+
 Embedding／pooling 模型只有輸入前向與 pooling，沒有自迴歸 decode，所以不應把
 生成服務的 ITL、output tokens/s 或長時間保留 decode KV 的直覺直接套用上去。
 然而這不代表 vLLM pooling runtime 必然完全沒有 cache 配置：vLLM V1 已為部分

--- a/mlops/vllm-performance-engineering/README.md
+++ b/mlops/vllm-performance-engineering/README.md
@@ -1,0 +1,269 @@
+# vLLM 效能工程：從顯存預算、KV cache 到量化與壓測
+
+> 更新日期：2026-08-11
+
+把 vLLM 啟動並不等於完成部署。真正的效能工程，是先定義 workload 與 SLO，
+再用可重現的實驗找出品質、延遲、吞吐量和顯存成本之間的 Pareto frontier。
+本文以 vLLM 官方文件、模型卡及原始論文為依據，建立可驗證、可重現的調校方法。
+
+## 先釐清：這是不是 MLOps 的工作？
+
+是，但組織分工沒有唯一答案。推論 runtime 調校通常落在 MLOps、LLMOps、ML
+platform 或 inference engineering 的交集：模型團隊定義品質門檻，平台團隊維護
+映像、容量、觀測與回滾，服務擁有者則決定 latency／throughput SLO。重要的不是
+職稱，而是以下責任有明確 owner：
+
+- 固定模型、runtime、driver 與 kernel 版本，確保結果可重現。
+- 以真實 prompt/output 長度和到達率壓測，而不是只跑單筆 demo。
+- 同時守住品質、錯誤率、p95/p99 latency 與單位 token 成本。
+- 用 metrics 判斷瓶頸，經過 canary 與 rollback 才變更 production 設定。
+
+## 推論的兩個階段，以及 embedding 的差異
+
+生成式 decoder-only LLM 的一次請求可以拆成：
+
+1. **Prefill**：平行處理 prompt tokens，通常較偏 compute-bound，決定 TTFT 的
+   重要部分。
+2. **Decode**：每一步產生少量新 token，反覆讀取模型權重與既有 KV cache，
+   常較偏 memory-bandwidth-bound，影響 ITL／TPOT。
+
+vLLM 的 continuous batching 會在每次 scheduler iteration 重新組合工作，不需要
+等一個靜態 batch 全部完成。V1 的 chunked prefill 在可用時預設開啟，會優先排
+decode，再把長 prefill 切塊塞入剩餘 token budget。因此 `max_num_batched_tokens`
+是「每次 iteration 最多處理多少 tokens」，`max_num_seqs` 才是「每次 iteration
+最多處理多少 sequences」；兩者都不是 API 同時連線數。
+
+Embedding／pooling 模型只有輸入前向與 pooling，沒有自迴歸 decode，所以不應把
+生成服務的 ITL、output tokens/s 或長時間保留 decode KV 的直覺直接套用上去。
+然而這不代表 vLLM pooling runtime 必然完全沒有 cache 配置：vLLM V1 已為部分
+last-pooling 模型提供 prefix caching 與 chunked prefill，實際配置仍依模型與版本
+而定。評估 embedding 應改看 batch tokens/s、requests/s、p95 latency、輸入長度
+分佈與 embedding 品質。
+
+## VRAM 不是只有模型權重
+
+可用以下預算式建立心智模型：
+
+```text
+runtime VRAM
+  = model weights
+  + KV / recurrent-state cache
+  + temporary activations and workspaces
+  + CUDA graphs and communication buffers
+  + allocator / CUDA context overhead
+```
+
+對一般 multi-head 或 grouped-query attention，未計 block padding 與實作額外成本
+時，每個 sequence token 的 KV cache 約為：
+
+```text
+KV bytes/token
+  = 2 × number_of_layers × number_of_kv_heads × head_dim × bytes_per_element
+      ^ K 與 V
+```
+
+總 KV 用量再乘上所有同時駐留 sequences 的 cached tokens。這解釋了為何 context
+長度、併發量、GQA/MQA 結構與 cache dtype 都很重要；只知道「模型是 8B」不能
+推算 KV cache。
+
+### `gpu_memory_utilization` 到底控制什麼？
+
+截至本文更新時，vLLM 官方文件把 `--gpu-memory-utilization` 定義為該 instance
+的 **model executor 總 GPU memory 比例**，最新文件預設值是 `0.92`。啟動時 vLLM
+會 profile 非 KV 記憶體，再把預算中的可用部分配置給 GPU cache。它不是「將
+GPU 的 92% 全部設為 KV cache」。若要精確控制 cache bytes，可用
+`--kv-cache-memory-bytes`；一旦指定，該值會覆蓋以 utilization 推導 cache 大小的
+方式。
+
+因此看到 Qwen3-Embedding-8B 使用約 16 GB，不能直接推論「16 GB 都是 KV
+cache」。官方模型卡標示模型為 8B parameters；若權重以 BF16/FP16 載入，僅權重
+的理論下限就約為 16 GB，尚未包含 allocator、activation 與 runtime buffer。
+
+另一個常見誤解是：降低 `max_model_len` 就會等比例縮小 vLLM 的 KV pool。它首先
+限制單一 sequence 的可接受長度與容量可行性；若總 GPU 預算不變，runtime 仍可能
+把剩餘空間建立成 cache blocks。要為同卡其他服務明確留空間，應調整
+`gpu_memory_utilization` 或 `kv_cache_memory_bytes`，再由啟動日誌和
+`nvidia-smi` 驗證，而不是只改 context 上限。
+
+## 何時應增加或減少 KV cache 預算？
+
+先用資料證明是 cache 壓力，不要看到 queue 就盲目加顯存。等待可能來自 KV
+不足，也可能是 scheduler token budget、模型計算、CPU tokenization 或上游限流。
+
+| 訊號與 workload | 判讀 | 優先實驗 |
+|---|---|---|
+| `num_preemptions` 持續增加，且 cache 接近滿載 | 高度可能是 KV 壓力 | 增加 cache 預算；或降低 `max_num_seqs`／`max_num_batched_tokens` |
+| 長 context、同時生成 sequences 多 | 每個 request 的 cached tokens 高 | 增加 cache、量化 KV、縮短 token budget，或做 workload 分池 |
+| `num_requests_waiting{reason="capacity"}` 上升，但 cache 不滿 | 可能是 scheduler／compute 容量 | sweep token budget 與 concurrency，不先增加 cache |
+| 高 cache 使用率但無排隊、preemption，SLO 正常 | 資源正在被有效利用 | 不因百分比高就變更 |
+| 同卡要 co-locate 多個服務 | 必須提供硬邊界 | 降低 utilization，最好用明確 bytes、獨立程序與 admission control |
+| pooling／embedding，短輸入為主 | decode cache 收益有限，但 batching 仍重要 | 降低預算做 A/B，增加 batch token budget，觀察 OOM 與吞吐 |
+| CUDA OOM | 不一定是 KV；也可能是 graph、activation 或 workspace peak | 先讀 stack/log，保留 headroom，再分別調低總預算或 batch |
+
+vLLM 官方 optimization guide 建議：頻繁 preemption 時可增加
+`gpu_memory_utilization`，或降低 `max_num_seqs`／`max_num_batched_tokens`。前者增加
+cache 容量，後兩者降低同一 iteration 的並行記憶體壓力。這是診斷後的選項，
+不是所有機器都適用的固定值。
+
+## 調度參數的真正 trade-off
+
+| 參數 | 主要限制 | 調高通常帶來 | 主要風險 |
+|---|---|---|---|
+| `max_num_seqs` | 每 iteration sequences 數 | 更多並行機會 | KV／activation 壓力與 tail latency |
+| `max_num_batched_tokens` | 每 iteration token budget | 更大的 prefill batch、較高吞吐或較佳 TTFT | decode 被大 prefill 影響，ITL 可能變差 |
+| `max_model_len` | 單 sequence 最大長度 | 接受更長請求 | 啟動容量門檻與單請求最壞資源需求上升 |
+| `gpu_memory_utilization` | instance 總顯存預算 | 通常留下更多 KV blocks | 給 graph、driver 或同卡程序的 headroom 下降 |
+| `kv_cache_memory_bytes` | 每 GPU cache 的明確 bytes | 容量可預測、便於 co-location | 設太大會擠壓其他 runtime 記憶體 |
+| `kv_cache_dtype` | KV 儲存精度 | FP8 可容納更多 tokens | 需要支援 kernel；應以資料校準並驗證品質 |
+
+官方 tuning guide 對 chunked prefill 的方向是：較小的 token budget 通常有利
+ITL，較大的值通常有利 TTFT 與吞吐；但分界會受模型、GPU 和長度分佈影響。
+不要把範例中的 `2048` 或 `>8192` 當成跨硬體常數。
+
+## 量化：權重大小、速度與品質是三個問題
+
+### 檔案和顯存會縮小，但不是完全相等
+
+只計算量化後的主要權重，`P` 個參數、每參數 `b` bits 的理想下限是：
+
+```text
+weight payload bytes ≈ P × b / 8
+```
+
+實際 checkpoint 還包含 scale、zero-point、metadata，以及可能保持高精度的
+embedding、normalization 或其他 tensors。載入 VRAM 後更要加上前述 cache、
+activation、graph 與 workspace。因此「檔案 18 GB，所以 runtime 只用 18 GB」
+並不成立。
+
+以 31B～32B dense model 為例，只看理想 weight payload：
+
+| 權重精度 | 理論 payload | 部署解讀 |
+|---|---:|---|
+| BF16／FP16 | 約 62～64 GB | 單張 32 GB GPU 放不下權重 |
+| FP8／INT8 | 約 31～32 GB | 幾乎沒有 runtime、activation 與 KV headroom，通常不適合直接塞入 32 GB |
+| 4-bit | 約 15.5～16 GB | checkpoint 常因 scales／高精度 tensors 更大，但通常可留下可用 headroom |
+
+這只是容量初篩，不是「需要多少 VRAM」的最終答案。最終值還取決於模型架構、
+量化格式、context、concurrency、backend kernel 與是否 offload。
+
+### 量化不保證更快
+
+Decode 經常受 memory bandwidth 限制，較小權重可能減少每步搬運量；但 prefill
+可能較偏 compute-bound，而低位元 kernel 支援、dequantization、batch shape 與
+硬體世代都會改變結果。某個 AWQ checkpoint 在一張 GPU 上快，不代表 GPTQ、
+GGUF 或同一格式在另一張 GPU 也快。速度必須在目標 runtime 與 workload 實測。
+
+### 大模型低位元，不是永遠勝過小模型高精度
+
+「永遠優先大模型 + 4-bit」不是可靠規則。模型家族、訓練資料、task、instruction
+following、安全性、長 context 與量化敏感度都可能改變排名。GPTQ 與 AWQ 論文
+證明特定模型在其評測設定下可大幅壓縮且維持接近原模型的品質；這不等於任何
+70B 4-bit 都必然勝過任何 8B BF16。
+
+正確方法是先定義任務品質 gate，再比較同一 VRAM／成本預算下的候選：
+
+1. 在未量化 checkpoint 建立 task-specific baseline。
+2. 對每個候選固定 prompt template、sampling、資料集與評分器。
+3. 同時量測品質、TTFT、ITL、throughput、p95/p99、VRAM 與錯誤率。
+4. 選擇通過品質門檻後成本最低或 SLO 最佳的版本。
+
+## AWQ、GPTQ 與 Q4_K_M 不只是三個「4-bit 副檔名」
+
+| 名稱 | 核心概念 | 常見 artifact／runtime | 注意事項 |
+|---|---|---|---|
+| AWQ | 用 activation statistics 找出 salient channels，透過 scaling 降低 weight-only quantization error | 常見為 Safetensors；vLLM 等 GPU runtimes | 原論文不是把「1% 權重另存高精度」這麼簡單；kernel 與硬體支援決定速度 |
+| GPTQ | 使用 approximate second-order information，逐層／逐 block 補償量化誤差 | 常見為 Safetensors；vLLM 等 GPU runtimes | bit width、group size、act-order 與 backend 都是 artifact contract 的一部分 |
+| Q4_K_M | GGUF 生態中的 K-quant 組合；可對不同 tensor 使用不同量化型別 | llama.cpp／GGUF 工具鏈 | `_M` 的實際 tensor 配置應讀 artifact metadata／quantizer，不應只靠名稱猜品質 |
+
+格式和演算法也不能完全混為一談：GGUF 是容器格式，Q4_K_M 是其中一種
+quantization recipe；AWQ、GPTQ 是量化方法，發布時仍需搭配實際 checkpoint 格式
+和相容 kernel。選型順序應是「模型支援 → artifact contract → runtime/kernel →
+實測」，不能只看到 `4-bit` 就視為等價。
+
+## 單張 32 GB GPU 的可重現練習路線
+
+以下場景用一張 32 GB GPU 就能完成，重點是每次只改一個因素。不要以刻意把
+production 打到 OOM 作為學習方法；在隔離環境設定 request timeout、concurrency
+上限與自動復原。
+
+### 實驗 0：固定基線
+
+保存 runtime image digest、模型 revision、dtype、driver、所有 engine arguments
+及 workload seed。準備至少三種長度分佈：短／短、長／短、長／長
+（input/output），先跑 warmup，再記錄冷啟動與穩態結果。
+
+### 實驗 1：顯存與 KV 邊界
+
+固定模型與流量，sweep 明確的 KV cache bytes 或 utilization。記錄啟動日誌中的
+weight、non-KV、cache 容量，以及 `kv_cache_usage_perc`、preemptions、waiting、
+TTFT/ITL。預期產物不是一個「最大值」，而是一條 concurrency × context 的容量
+曲線。
+
+### 實驗 2：低延遲與高吞吐 Pareto frontier
+
+對 `max_num_seqs`、`max_num_batched_tokens` 做小型 grid search；每組同時測閉環
+concurrency 與開環 request rate。使用 `vllm bench serve` 固定 input/output length、
+request rate、burstiness 與 max concurrency，保存詳細 JSON，而非只截終端平均值。
+
+### 實驗 3：prefix caching 與量化
+
+Prefix cache A/B 應包含兩組流量：高比例相同且 block-aligned 的長前綴，以及完全
+不同前綴。若只測重複 prompt，會高估真實收益。量化 A/B 則必須加入 task-specific
+品質 gate；不能只比較 tokens/s 和 VRAM。
+
+### 實驗 4：embedding 專用 workload
+
+對 pooling 模型 sweep 輸入 token 長度、batch token budget、concurrency 與
+utilization。比較 vLLM 與專用 embedding runtime 時，使用完全相同的 tokenizer、
+normalization、instruction 與輸出維度，否則速度數據和向量品質都不可比。
+
+## 生產觀測與告警
+
+vLLM 官方 `/metrics` 暴露的核心訊號包括：
+
+- `vllm:num_requests_running` 與 `vllm:num_requests_waiting`。
+- `vllm:num_requests_waiting_by_reason`，可區分 capacity 與 deferred。
+- `vllm:kv_cache_usage_perc` 與 `vllm:num_preemptions`。
+- `vllm:time_to_first_token_seconds`、`vllm:inter_token_latency_seconds`、
+  `vllm:e2e_request_latency_seconds` 與 queue time。
+- prompt／generation tokens counters，用來正規化吞吐與成本。
+
+不要用「cache > 90% 且 waiting > 5」這類無 workload 背景的固定數字直接決定
+擴容。告警應基於持續時間與使用者 SLO，例如 p95 queue time 超標、preemption
+rate 持續上升、錯誤率或 timeout 超標；容量動作則要先區分 cache、compute、CPU
+與上游 admission control 瓶頸。
+
+## 一份可靠的調校順序
+
+1. 固定版本、模型 artifact、品質 gate 與 workload trace。
+2. 先確定權重能載入並保留安全 headroom。
+3. 以 context × concurrency sweep 找出 cache／preemption 邊界。
+4. 再調 scheduler token/sequence budget，畫 latency-throughput frontier。
+5. Prefix cache、KV quantization、weight quantization 每次只開一項並重跑品質 gate。
+6. 用 production metrics 驗證實驗結論，而不是把 benchmark 最快組合直接上線。
+
+## 結論
+
+vLLM 不會只憑 GPU 型號替服務自動找到「最佳 batch 或 concurrency」。它會依可用
+顯存 profile cache 容量，scheduler 也會動態組 batch；但 SLO、流量分佈與品質
+門檻仍必須由部署者提供。超出當下執行容量的請求通常會等待、被後續 iteration
+排入，KV 壓力下也可能 preempt/recompute；這和「所有請求固定 FIFO、一批跑完
+才跑下一批」不同。
+
+最可靠的能力不是背下某組參數，而是能從模型結構和顯存預算提出假設，用可重現
+壓測與 metrics 證偽，再把結果轉成有回滾能力的部署設定。
+
+## 參考資料
+
+- [vLLM Engine Arguments](https://docs.vllm.ai/en/latest/configuration/engine_args/)
+- [vLLM Optimization and Tuning](https://docs.vllm.ai/en/latest/configuration/optimization/)
+- [vLLM Production Metrics](https://docs.vllm.ai/en/latest/usage/metrics/)
+- [vLLM Pooling Models](https://docs.vllm.ai/en/latest/models/pooling_models/)
+- [vLLM V1 User Guide](https://docs.vllm.ai/en/latest/usage/v1_guide/)
+- [vLLM Benchmark Serve CLI](https://docs.vllm.ai/en/latest/cli/bench/serve/)
+- [vLLM Quantized KV Cache](https://docs.vllm.ai/en/latest/features/quantization/quantized_kvcache/)
+- [Efficient Memory Management for Large Language Model Serving with PagedAttention](https://arxiv.org/abs/2309.06180)
+- [AWQ: Activation-aware Weight Quantization for LLM Compression and Acceleration](https://arxiv.org/abs/2306.00978)
+- [GPTQ: Accurate Post-Training Quantization for Generative Pre-trained Transformers](https://arxiv.org/abs/2210.17323)
+- [llama.cpp Quantization README](https://github.com/ggml-org/llama.cpp/blob/master/tools/quantize/README.md)
+- [Qwen3-Embedding-8B model card](https://huggingface.co/Qwen/Qwen3-Embedding-8B)


### PR DESCRIPTION
## Summary

- explain artifact-first runtime selection across vLLM, llama.cpp, and TEI
- add a generic workload-based llama.cpp vs vLLM decision matrix
- apply the framework to Muse Glimmer 30B as a model-specific case
- add a verified vLLM performance-engineering note covering VRAM budgeting, KV cache, scheduling, quantization, benchmarking, and observability
- correct and curate the FlashAttention/PagedAttention notes, removing unsupported absolutes and unrelated benchmark/reference noise
- cross-link the attention architecture note from both MLOps articles

## Validation

- `git diff --check`
- verified technical claims against official vLLM documentation, official implementations, model cards, and primary papers
- verified local cross-links resolve