### PR TITLE
docs(mlops): resource awareness and TTS tuning experiments

### DIFF
--- a/mlops/README.md
+++ b/mlops/README.md
@@ -1,10 +1,11 @@
-# MLOps 實務筆記
+# MLOps Field Notes
 
-這個目錄收錄模型部署、資源管理與效能工程的實務筆記。每篇文章描述可重現的
-診斷方法與決策邊界，不把單一模型或單一叢集的參數當成通用預設值。
+> **English** | [繁體中文](./README.zh-TW.md)
 
-| 主題 | 重點 |
+This directory collects field notes on model deployment, resource management, and performance engineering. Each note documents reproducible diagnostic methods and decision boundaries instead of treating settings from one model or cluster as universal defaults.
+
+| Topic | Focus |
 | --- | --- |
-| [容器內 ML workload 的資源感知](./container-resource-awareness/) | Host-visible 資源與 Pod cgroup 實際預算的落差、thread oversubscription、GPU sharing、NUMA、`/dev/shm` 與儲存容量 |
-| [語言模型部署](./language-model-deployment/) | 依 artifact、硬體與 workload 選擇 vLLM、llama.cpp 或 TEI |
-| [vLLM 效能工程](./vllm-performance-engineering/) | 併發、KV cache 與 serving benchmark 的量測方法 |
+| [Resource-aware ML workloads in containers](./container-resource-awareness/) ([繁體中文](./container-resource-awareness/README.zh-TW.md)) | Gaps between host-visible resources and the actual Pod cgroup budget, thread oversubscription, GPU sharing, NUMA, `/dev/shm`, and storage capacity |
+| [Language model deployment](./language-model-deployment/) | Choosing vLLM, llama.cpp, or TEI based on artifacts, hardware, and workload |
+| [vLLM performance engineering](./vllm-performance-engineering/) | Measuring concurrency, KV cache behavior, and serving benchmarks |

--- a/mlops/README.md
+++ b/mlops/README.md
@@ -7,5 +7,6 @@ This directory collects field notes on model deployment, resource management, an
 | Topic | Focus |
 | --- | --- |
 | [Resource-aware ML workloads in containers](./container-resource-awareness/) ([繁體中文](./container-resource-awareness/README.zh-TW.md)) | Gaps between host-visible resources and the actual Pod cgroup budget, thread oversubscription, GPU sharing, NUMA, `/dev/shm`, and storage capacity |
+| [Layer-by-layer TTS inference tuning](./tts-inference-performance-tuning/) ([繁體中文](./tts-inference-performance-tuning/README.zh-TW.md)) | Production-shaped A/B tests for BERT device transfers and batching, internal segment shape, TTS batch size, and outer checkpoint boundaries |
 | [Language model deployment](./language-model-deployment/) | Choosing vLLM, llama.cpp, or TEI based on artifacts, hardware, and workload |
 | [vLLM performance engineering](./vllm-performance-engineering/) | Measuring concurrency, KV cache behavior, and serving benchmarks |

--- a/mlops/README.md
+++ b/mlops/README.md
@@ -1,0 +1,10 @@
+# MLOps 實務筆記
+
+這個目錄收錄模型部署、資源管理與效能工程的實務筆記。每篇文章描述可重現的
+診斷方法與決策邊界，不把單一模型或單一叢集的參數當成通用預設值。
+
+| 主題 | 重點 |
+| --- | --- |
+| [容器內 ML workload 的資源感知](./container-resource-awareness/) | Host-visible 資源與 Pod cgroup 實際預算的落差、thread oversubscription、GPU sharing、NUMA、`/dev/shm` 與儲存容量 |
+| [語言模型部署](./language-model-deployment/) | 依 artifact、硬體與 workload 選擇 vLLM、llama.cpp 或 TEI |
+| [vLLM 效能工程](./vllm-performance-engineering/) | 併發、KV cache 與 serving benchmark 的量測方法 |

--- a/mlops/README.zh-TW.md
+++ b/mlops/README.zh-TW.md
@@ -1,0 +1,12 @@
+# MLOps 實務筆記
+
+> [English](./README.md) | **繁體中文**
+
+這個目錄收錄模型部署、資源管理與效能工程的實務筆記。每篇文章描述可重現的
+診斷方法與決策邊界，不把單一模型或單一叢集的參數當成通用預設值。
+
+| 主題 | 重點 |
+| --- | --- |
+| [容器內 ML workload 的資源感知](./container-resource-awareness/README.zh-TW.md)（[English](./container-resource-awareness/)） | Host-visible 資源與 Pod cgroup 實際預算的落差、thread oversubscription、GPU sharing、NUMA、`/dev/shm` 與儲存容量 |
+| [語言模型部署](./language-model-deployment/) | 依 artifact、硬體與 workload 選擇 vLLM、llama.cpp 或 TEI |
+| [vLLM 效能工程](./vllm-performance-engineering/) | 併發、KV cache 與 serving benchmark 的量測方法 |

--- a/mlops/README.zh-TW.md
+++ b/mlops/README.zh-TW.md
@@ -8,5 +8,6 @@
 | 主題 | 重點 |
 | --- | --- |
 | [容器內 ML workload 的資源感知](./container-resource-awareness/README.zh-TW.md)（[English](./container-resource-awareness/)） | Host-visible 資源與 Pod cgroup 實際預算的落差、thread oversubscription、GPU sharing、NUMA、`/dev/shm` 與儲存容量 |
+| [逐層調教 TTS 推論](./tts-inference-performance-tuning/README.zh-TW.md)（[English](./tts-inference-performance-tuning/)） | BERT device transfer／batching、內部分段 shape、TTS batch 與外層 checkpoint 邊界的 production-shaped A/B |
 | [語言模型部署](./language-model-deployment/) | 依 artifact、硬體與 workload 選擇 vLLM、llama.cpp 或 TEI |
 | [vLLM 效能工程](./vllm-performance-engineering/) | 併發、KV cache 與 serving benchmark 的量測方法 |

--- a/mlops/container-resource-awareness/README.md
+++ b/mlops/container-resource-awareness/README.md
@@ -1,0 +1,170 @@
+# 容器內 ML workload 的資源感知：別把 host-visible 當成 Pod budget
+
+> 更新日期：2026-08-28
+
+在 Kubernetes 裡，模型明明只被配置 8 CPU，PyTorch、OpenMP、MKL、ONNX Runtime
+或資料前處理程序卻可能建立遠多於 8 個執行緒。節點監控甚至可能顯示大量 CPU
+idle，但 Pod 內的推論仍斷斷續續、延遲暴增。
+
+這不是套件真的「繞過 Pod」取得額外資源。更精確的說法是：
+
+- **資源偵測（discovery）**可能看到 host CPU、physical cores、CPU affinity 或套件自己的
+  預設值，並據此建立 thread pool。
+- **資源執法（enforcement）**仍由 Linux cgroup 執行 Kubernetes 的 CPU、memory 等限制。
+- discovery 與 enforcement 對同一 workload 的預算理解不同，就會發生 oversubscription。
+
+Kubernetes [明確說明 CPU limit 是由 kernel throttling 強制執行](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits)；它不是 thread pool
+大小，也不會自動替每個 ML runtime 選出合理的平行度。因此，`resources.limits.cpu: 8`
+不能取代 `OMP_NUM_THREADS=8`、`torch.set_num_threads(8)` 或相應 runtime 設定。
+
+## 為什麼全機 CPU idle，Pod 還是會被 throttle
+
+假設節點有 128 cores，Pod 的 CPU limit 是 8。以常見的 100 ms CFS period 為例，
+該 Pod 在每個 period 共有約 800 ms 的 aggregate CPU time：
+
+- 8 個持續工作的 threads 可以把預算均勻用完整個 100 ms。
+- 64 個 threads 理論上約 12.5 ms 就能一起用完 800 ms，之後整個 cgroup 等待下一個 period。
+- 其餘約 120 個 host cores 即使保持 idle，也不能借給已碰到 hard limit 的 Pod。
+
+對 BERT 這種包含許多小型 operator、barrier 與逐句呼叫的路徑，quota burst 還會疊加：
+
+- OpenMP、MKL、OpenBLAS、PyTorch intra-op/inter-op 各自建立或喚醒 worker。
+- 多個 Python worker、DataLoader 或 serving process 再乘上一層 thread pool。
+- context switch、cache thrashing 與 thread-pool spinning 消耗預算。
+- barrier 只要等到一個被延後的 worker，整個 operator 就無法完成。
+
+所以限制 thread 數後變快，不代表「thread 越少越好」；它代表**有效平行度終於和
+cgroup 可用預算對齊**。
+
+一個實際案例中，約 128-core 節點上的 TTS Pod 限制為 8 CPU，程序總 thread 數約
+273。cgroup 觀察到 82 個 throttled periods，以及約 417 秒的累積 throttled time；舊路徑
+處理 85 句 BERT 曾耗時約 14 分 54 秒。將 PyTorch/BLAS 的數值計算 thread pools 對齊
+8 CPU 後，另一筆真實 workload 的 73 句前處理約 7 秒，單次 BERT forward 多數約
+25–40 ms。
+
+這不是嚴格控制所有變因的 benchmark，不能據此宣稱每個模型都應固定設成 8；但它證明
+了兩件事：全機 idle 不能排除 Pod throttling，而且 thread budget 必須是 workload contract
+的一部分。歷史慢請求發生時尚無 phase-level watchdog，因此不能回溯宣稱某一個 BERT
+operator 是唯一根因。
+
+## 業界常見資源認知落差比較表
+
+| 落差 | 套件／程序常看到什麼 | 實際限制或競爭點 | 常見症狀 | 優先處理方式 | 應觀測的證據 |
+| --- | --- | --- | --- | --- | --- |
+| CPU topology vs CPU quota | Host logical/physical CPU、affinity，或 runtime 預設 thread 數 | cgroup CPU quota/period | 節點 idle 但 Pod latency 呈週期性尖峰、`throttled` 持續增加 | 以 effective CPU budget 設定 intra-op、inter-op、OMP、MKL、OpenBLAS；先量測再調整 | [`cpu.stat` 與 CPU limit](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#how-kubernetes-applies-resource-requests-and-limits)、throttled ratio/time、run queue、phase latency、runtime thread 數 |
+| Process 數 × thread pool | 每個 worker 都認為自己可使用完整 CPU | 所有 workers 共用同一 Pod/cgroup quota | worker 增加後吞吐不升反降，context switches 與 load 暴增 | 先決定 process concurrency，再把每個 process 的 thread budget 分配到總 CPU 預算內 | process/thread 數、context switches、CPU PSI、每 worker throughput |
+| CPU request vs limit vs exclusive cores | Application 通常只知道可執行 CPU，不理解 Kubernetes QoS | request 影響排程與競爭權重；limit 是 hard ceiling；exclusive CPU 還需要 static CPU Manager、Guaranteed Pod 與整數 CPU request | 同規格 Pod 在不同節點 latency 差異大，與 sidecar/host process 互相干擾 | latency-sensitive workload 才評估 Guaranteed + static CPU Manager；一般 workload 先正確配置 request/limit | Pod QoS、cpuset、CPU Manager policy、steal/throttling、node noise |
+| Host RAM vs cgroup memory | Runtime、cache 或 allocator 可能依 host RAM 規劃 | Pod memory limit、tmpfs `emptyDir` 也可能計入 container memory | Node 看似有 RAM，但 Pod `OOMKilled`；page cache、模型 cache 或 tmpfs 推高 working set | 以 cgroup memory budget 設 cache、batch、prefetch；為 memory-backed volume 設 `sizeLimit` | working set/RSS、cgroup memory events、OOM reason、tmpfs/cache bytes |
+| `/dev/shm` vs DataLoader/IPC 需求 | multiprocessing 假設有足夠 POSIX shared memory | [Docker 預設 `/dev/shm` 只有 64 MiB](https://docs.docker.com/engine/containers/run/#runtime-constraints-on-resources)；Kubernetes volume 配置另行決定 | DataLoader bus error、NCCL/IPC 初始化失敗、大 batch 才偶發 | 明確配置 memory-backed `emptyDir` 或 runtime shm size，並把它納入 memory capacity | `df -h /dev/shm`、shared-memory 使用量、worker exit reason |
+| GPU device count vs 可用算力／VRAM | `CUDA_VISIBLE_DEVICES` 顯示一張 GPU | [NVIDIA time-slicing](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html#understanding-time-slicing-gpus) 只共享時間，沒有 MIG 等級的 memory/fault isolation；其他 sharing layer 也可能另有 VRAM/core contract | Pod 看得到 GPU 卻 OOM、latency 抖動，或兩個 workload 互相拖慢 | 明確選擇 exclusive、MIG、time-slicing 或 vendor vGPU；不要把「1 GPU」當成固定算力與 VRAM | per-process VRAM、SM utilization、allocator peak、Xid/OOM、sharing mode |
+| CPU/NUMA/GPU locality | Runtime 看到所有 CPUs 與一張可見 GPU | CPU、RAM 與 PCIe GPU 可能跨 NUMA node | Host utilization 正常但 H2D、tokenization 或 input pipeline latency 高且不穩 | 需要時使用 Topology Manager、CPU Manager/cpuset，並驗證 memory locality；不要只做 CPU pinning | NUMA miss、PCIe throughput、CPU affinity、GPU topology、phase latency |
+| Container writable layer vs 模型／checkpoint 大小 | Application 把 `/tmp`、HF cache、Torch cache 視為一般磁碟 | ephemeral-storage limit、node disk pressure、image pull/unpack 與 log 也競爭本機磁碟 | `Evicted`、`ENOSPC`、啟動或 checkpoint 變慢，重啟後 cache 消失 | 模型與大型 cache 放明確 volume；配置 ephemeral request/limit、清理與水位告警 | volume/rootfs bytes、inode、ephemeral-storage events、pull/unpack latency |
+| Runtime spinning vs 真實工作量 | Runtime 為降低單次延遲讓 idle worker spin | 多個模型／session 共用 CPU 時，spinning 會消耗 quota 與電力 | 沒有請求仍有固定 CPU，其他服務 p95 上升 | 依 latency/throughput 目標關閉或縮短 spinning；不要僅看單 request benchmark | idle CPU、power、session/thread 數、p50/p99、throttled time |
+
+表中的控制方式不是可以直接複製的固定模板。例如 Kubernetes static CPU Manager 只有在
+節點正確設定，且 container 位於 Guaranteed Pod、具有整數 CPU request 時，才會分配
+exclusive CPUs（見 [Kubernetes CPU Manager](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy-configuration)）。GPU time-slicing 也不等同 VRAM 隔離；NVIDIA 文件明確指出它沒有
+memory 或 fault isolation。
+
+## 常見 ML runtime 的 CPU 控制面
+
+| Runtime／library | 主要控制方式 | 常見陷阱 |
+| --- | --- | --- |
+| PyTorch | `OMP_NUM_THREADS`、`MKL_NUM_THREADS`、`torch.set_num_threads()`、`torch.set_num_interop_threads()` | 必須在 eager/JIT/autograd 工作開始前設定；總 process threads 不會等於數值計算 threads |
+| NumPy + BLAS | `OMP_NUM_THREADS`、OpenBLAS/MKL 對應變數，或 `threadpoolctl` | NumPy 本身常是單 thread，但背後 BLAS 可以另外開多 thread |
+| TensorFlow | `tf.config.threading.set_intra_op_parallelism_threads()`、`set_inter_op_parallelism_threads()` | `tf.data`、serving workers 與 operator thread pools 可能形成多層平行 |
+| ONNX Runtime | `intra_op_num_threads`、`inter_op_num_threads`、execution mode、thread spinning 設定 | [預設 intra-op pool 可依 physical cores 建立](https://onnxruntime.ai/docs/performance/tune-performance/threading.html#intra-thread-count)；多個 session 會重複建立 pool |
+| DataLoader／multiprocessing | process/worker 數、prefetch、每個 child 的 BLAS/PyTorch threads | `workers × threads` 才是總 CPU 壓力；fork/spawn 行為與共享記憶體也要納入 |
+| Serving engine | request concurrency、batch/token budget、CPU preprocess workers | GPU batch 調大不代表 CPU tokenizer、音訊編碼、publisher 有足夠容量 |
+
+設定環境變數要早於 NumPy、PyTorch 或會載入 BLAS/OpenMP 的套件 import。只在模型載入後
+修改，可能已經建立 thread pool，結果依 runtime 而異。
+
+```python
+import os
+
+# 這個數字應由 deployment 的 effective CPU budget 注入，不應硬編碼成所有服務共用值。
+threads = int(os.environ["ML_CPU_THREADS"])
+for name in ("OMP_NUM_THREADS", "MKL_NUM_THREADS", "OPENBLAS_NUM_THREADS", "NUMEXPR_NUM_THREADS"):
+    os.environ[name] = str(threads)
+
+import torch
+
+torch.set_num_threads(threads)
+torch.set_num_interop_threads(min(2, threads))
+```
+
+Kubernetes 可以用 [`resourceFieldRef`](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api) 把 container CPU limit 以 millicores 注入 entrypoint，
+再由 entrypoint 轉成有上下界的 thread budget：
+
+```yaml
+resources:
+  requests:
+    cpu: "8"
+    memory: 32Gi
+  limits:
+    cpu: "8"
+    memory: 32Gi
+env:
+  - name: CONTAINER_CPU_LIMIT_MILLICORES
+    valueFrom:
+      resourceFieldRef:
+        containerName: inference
+        resource: limits.cpu
+        divisor: 1m
+```
+
+應用仍要驗證值存在、可解析並落在 release 支援的範圍；不要讓缺少 limit 變成 0 threads，
+也不要看到 64 host CPUs 就自動採用 64。若 Pod 有 sidecar，每個 container 的 budget 與整個
+Pod 的 QoS/資源總和都必須分別核對。
+
+## 診斷順序：從「哪一層在等」開始
+
+1. **拆 phase timer。** 將 normalization、tokenizer、H2D、model forward、postprocess、encode、
+   publish 分開量測；只有 end-to-end latency 無法區分 CPU、GPU、I/O 或 queue。
+2. **同時看 node 與 cgroup。** Node idle 不會否定 container throttling；Node busy 也不代表
+   該 request 一定在 CPU 上。
+3. **讀 effective CPU。** 比較 affinity/cpuset 與 quota/period。可用的平行度上界概念上是：
+
+   ```text
+   effective_cpu = min(cpuset_cpu_count, cpu_quota / cpu_period)
+   ```
+
+   quota 若為 unlimited，才只看 cpuset/affinity。fractional CPU 需要以 benchmark 決定 thread
+   數，不能直接把小數無條件進位。
+4. **列出所有 thread pools。** 除了 framework，還要包含 BLAS、tokenizer、DataLoader、web
+   server、Celery/Ray workers、ffmpeg 與 sidecar。
+5. **做相同輸入 A/B。** 固定 model、input、batch、GPU profile 與同機競爭 workload，只改
+   thread budget；比較 throughput、p50/p95/p99、throttling 與輸出品質。
+6. **保留 watchdog 與 stack。** phase 超時時輸出所有 thread stack，再由 orchestrator 重啟；
+   restart 是止血，不是根因證明。
+
+對 cgroup v2，`cpu.stat` 的 `nr_periods`、`nr_throttled`、`throttled_usec` 與 `cpu.max` 是重要
+證據；cgroup v1 使用對應的 `cpu.stat`、`cpu.cfs_quota_us` 與 `cpu.cfs_period_us`。監控系統可能
+以不同 metric 名稱暴露相同資料，runbook 應保存實際查詢，而不是只寫 dashboard 截圖。
+
+## Production checklist
+
+- [ ] Deployment 明確宣告 CPU/memory requests 與 limits。
+- [ ] Application thread budget 來自 effective CPU，而不是 host CPU count。
+- [ ] `process concurrency × threads per process` 不超出經 benchmark 證明的容量。
+- [ ] Phase metrics、cgroup throttling、OOM、GPU allocated/reserved 與 queue age 可觀測。
+- [ ] `/dev/shm`、tmpfs、ephemeral storage、model cache 與 checkpoint 有容量上限。
+- [ ] GPU sharing 模式、VRAM/fault isolation 與 workload request 語意一致。
+- [ ] Latency-sensitive Pod 若要求 exclusive CPU，已驗證 QoS、整數 request、CPU Manager 與 NUMA。
+- [ ] 相同輸入做過冷啟動、穩態、並發與同機 noisy-neighbor A/B。
+- [ ] watchdog 能指出停滯 phase；重啟後任務具 checkpoint、冪等與安全重試。
+
+## 參考資料
+
+- [Kubernetes：Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+- [Kubernetes：Control CPU Management Policies on the Node](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/)
+- [PyTorch：Threading Environment Variables](https://docs.pytorch.org/docs/stable/threading_environment_variables.html)
+- [PyTorch：CPU threading and TorchScript inference](https://docs.pytorch.org/docs/stable/notes/cpu_threading_torchscript_inference.html)
+- [PyTorch：`torch.set_num_threads`](https://docs.pytorch.org/docs/stable/generated/torch.set_num_threads.html)
+- [NumPy：Number of threads used for linear algebra](https://numpy.org/doc/stable/reference/global_state.html#number-of-threads-used-for-linear-algebra)
+- [TensorFlow：Configure intra-op parallelism](https://www.tensorflow.org/api_docs/python/tf/config/threading/set_intra_op_parallelism_threads)
+- [TensorFlow：Configure inter-op parallelism](https://www.tensorflow.org/api_docs/python/tf/config/threading/set_inter_op_parallelism_threads)
+- [ONNX Runtime：Thread management](https://onnxruntime.ai/docs/performance/tune-performance/threading.html)
+- [Docker：Runtime constraints on resources](https://docs.docker.com/engine/containers/run/#runtime-constraints-on-resources)
+- [NVIDIA GPU Operator：Time-Slicing GPUs in Kubernetes](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html)

--- a/mlops/container-resource-awareness/README.md
+++ b/mlops/container-resource-awareness/README.md
@@ -1,89 +1,73 @@
-# 容器內 ML workload 的資源感知：別把 host-visible 當成 Pod budget
+# Resource-Aware ML Workloads in Containers: Host-Visible Is Not the Pod Budget
 
-> 更新日期：2026-08-28
+> **English** | [繁體中文](./README.zh-TW.md)
 
-在 Kubernetes 裡，模型明明只被配置 8 CPU，PyTorch、OpenMP、MKL、ONNX Runtime
-或資料前處理程序卻可能建立遠多於 8 個執行緒。節點監控甚至可能顯示大量 CPU
-idle，但 Pod 內的推論仍斷斷續續、延遲暴增。
+> Updated: 2026-08-28
 
-這不是套件真的「繞過 Pod」取得額外資源。更精確的說法是：
+In Kubernetes, a model may be assigned only 8 CPUs while PyTorch, OpenMP, MKL, ONNX Runtime, or data-preprocessing code creates far more than 8 threads. Node monitoring may even show substantial idle CPU while inference inside the Pod remains intermittent and latency spikes.
 
-- **資源偵測（discovery）**可能看到 host CPU、physical cores、CPU affinity 或套件自己的
-  預設值，並據此建立 thread pool。
-- **資源執法（enforcement）**仍由 Linux cgroup 執行 Kubernetes 的 CPU、memory 等限制。
-- discovery 與 enforcement 對同一 workload 的預算理解不同，就會發生 oversubscription。
+This does not mean the libraries truly bypass the Pod to obtain additional resources. More precisely:
 
-Kubernetes [明確說明 CPU limit 是由 kernel throttling 強制執行](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits)；它不是 thread pool
-大小，也不會自動替每個 ML runtime 選出合理的平行度。因此，`resources.limits.cpu: 8`
-不能取代 `OMP_NUM_THREADS=8`、`torch.set_num_threads(8)` 或相應 runtime 設定。
+- **Resource discovery** may observe host CPUs, physical cores, CPU affinity, or a library's own defaults and size a thread pool from that information.
+- **Resource enforcement** still applies Kubernetes CPU and memory limits through Linux cgroups.
+- Oversubscription occurs when discovery and enforcement disagree about the budget available to the same workload.
 
-## 為什麼全機 CPU idle，Pod 還是會被 throttle
+Kubernetes [explicitly states that CPU limits are enforced through kernel throttling](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits). A CPU limit is neither a thread-pool size nor a mechanism that automatically chooses sensible parallelism for every ML runtime. Therefore, `resources.limits.cpu: 8` does not replace `OMP_NUM_THREADS=8`, `torch.set_num_threads(8)`, or the corresponding runtime controls.
 
-假設節點有 128 cores，Pod 的 CPU limit 是 8。以常見的 100 ms CFS period 為例，
-該 Pod 在每個 period 共有約 800 ms 的 aggregate CPU time：
+## Why a Pod Can Be Throttled While the Host CPU Is Idle
 
-- 8 個持續工作的 threads 可以把預算均勻用完整個 100 ms。
-- 64 個 threads 理論上約 12.5 ms 就能一起用完 800 ms，之後整個 cgroup 等待下一個 period。
-- 其餘約 120 個 host cores 即使保持 idle，也不能借給已碰到 hard limit 的 Pod。
+Suppose a node has 128 cores and a Pod has a CPU limit of 8. With a typical 100 ms CFS period, the Pod receives about 800 ms of aggregate CPU time per period:
 
-對 BERT 這種包含許多小型 operator、barrier 與逐句呼叫的路徑，quota burst 還會疊加：
+- 8 continuously busy threads can spread that budget across the full 100 ms.
+- 64 threads can theoretically consume all 800 ms together in about 12.5 ms, after which the entire cgroup waits for the next period.
+- Even if the other 120 host cores remain idle, they cannot be borrowed by a Pod that has reached its hard limit.
 
-- OpenMP、MKL、OpenBLAS、PyTorch intra-op/inter-op 各自建立或喚醒 worker。
-- 多個 Python worker、DataLoader 或 serving process 再乘上一層 thread pool。
-- context switch、cache thrashing 與 thread-pool spinning 消耗預算。
-- barrier 只要等到一個被延後的 worker，整個 operator 就無法完成。
+For BERT paths containing many small operators, barriers, and per-sentence calls, quota bursts compound with other effects:
 
-所以限制 thread 數後變快，不代表「thread 越少越好」；它代表**有效平行度終於和
-cgroup 可用預算對齊**。
+- OpenMP, MKL, OpenBLAS, and PyTorch intra-op/inter-op execution may each create or wake workers.
+- Multiple Python workers, DataLoaders, or serving processes can multiply another layer of thread pools.
+- Context switching, cache thrashing, and thread-pool spinning consume the budget.
+- If a barrier waits for even one delayed worker, the entire operator cannot finish.
 
-一個實際案例中，約 128-core 節點上的 TTS Pod 限制為 8 CPU，程序總 thread 數約
-273。cgroup 觀察到 82 個 throttled periods，以及約 417 秒的累積 throttled time；舊路徑
-處理 85 句 BERT 曾耗時約 14 分 54 秒。將 PyTorch/BLAS 的數值計算 thread pools 對齊
-8 CPU 後，另一筆真實 workload 的 73 句前處理約 7 秒，單次 BERT forward 多數約
-25–40 ms。
+The speedup after limiting threads does not mean that fewer threads are always better. It means that **effective parallelism finally matches the budget available to the cgroup**.
 
-這不是嚴格控制所有變因的 benchmark，不能據此宣稱每個模型都應固定設成 8；但它證明
-了兩件事：全機 idle 不能排除 Pod throttling，而且 thread budget 必須是 workload contract
-的一部分。歷史慢請求發生時尚無 phase-level watchdog，因此不能回溯宣稱某一個 BERT
-operator 是唯一根因。
+In one real incident, a TTS Pod on a roughly 128-core node had an 8-CPU limit while the process had about 273 threads. The cgroup recorded 82 throttled periods and about 417 seconds of cumulative throttled time. On the old path, processing 85 BERT sentences once took about 14 minutes 54 seconds. After aligning the PyTorch and BLAS numerical thread pools with the 8-CPU budget, preprocessing another real workload of 73 sentences took about 7 seconds, and most individual BERT forwards took about 25–40 ms.
 
-## 業界常見資源認知落差比較表
+This was not a benchmark with every variable strictly controlled, so it does not prove that every model should be fixed at 8 threads. It does establish two points: host-level idle capacity does not rule out Pod throttling, and the thread budget must be part of the workload contract. The historical slow request had no phase-level watchdog, so the evidence cannot retrospectively prove that one BERT operator was the sole root cause.
 
-| 落差 | 套件／程序常看到什麼 | 實際限制或競爭點 | 常見症狀 | 優先處理方式 | 應觀測的證據 |
+## Common Resource-Perception Gaps in Production
+
+| Gap | What the library or process may see | Actual constraint or contention point | Common symptom | First response | Evidence to observe |
 | --- | --- | --- | --- | --- | --- |
-| CPU topology vs CPU quota | Host logical/physical CPU、affinity，或 runtime 預設 thread 數 | cgroup CPU quota/period | 節點 idle 但 Pod latency 呈週期性尖峰、`throttled` 持續增加 | 以 effective CPU budget 設定 intra-op、inter-op、OMP、MKL、OpenBLAS；先量測再調整 | [`cpu.stat` 與 CPU limit](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#how-kubernetes-applies-resource-requests-and-limits)、throttled ratio/time、run queue、phase latency、runtime thread 數 |
-| Process 數 × thread pool | 每個 worker 都認為自己可使用完整 CPU | 所有 workers 共用同一 Pod/cgroup quota | worker 增加後吞吐不升反降，context switches 與 load 暴增 | 先決定 process concurrency，再把每個 process 的 thread budget 分配到總 CPU 預算內 | process/thread 數、context switches、CPU PSI、每 worker throughput |
-| CPU request vs limit vs exclusive cores | Application 通常只知道可執行 CPU，不理解 Kubernetes QoS | request 影響排程與競爭權重；limit 是 hard ceiling；exclusive CPU 還需要 static CPU Manager、Guaranteed Pod 與整數 CPU request | 同規格 Pod 在不同節點 latency 差異大，與 sidecar/host process 互相干擾 | latency-sensitive workload 才評估 Guaranteed + static CPU Manager；一般 workload 先正確配置 request/limit | Pod QoS、cpuset、CPU Manager policy、steal/throttling、node noise |
-| Host RAM vs cgroup memory | Runtime、cache 或 allocator 可能依 host RAM 規劃 | Pod memory limit、tmpfs `emptyDir` 也可能計入 container memory | Node 看似有 RAM，但 Pod `OOMKilled`；page cache、模型 cache 或 tmpfs 推高 working set | 以 cgroup memory budget 設 cache、batch、prefetch；為 memory-backed volume 設 `sizeLimit` | working set/RSS、cgroup memory events、OOM reason、tmpfs/cache bytes |
-| `/dev/shm` vs DataLoader/IPC 需求 | multiprocessing 假設有足夠 POSIX shared memory | [Docker 預設 `/dev/shm` 只有 64 MiB](https://docs.docker.com/engine/containers/run/#runtime-constraints-on-resources)；Kubernetes volume 配置另行決定 | DataLoader bus error、NCCL/IPC 初始化失敗、大 batch 才偶發 | 明確配置 memory-backed `emptyDir` 或 runtime shm size，並把它納入 memory capacity | `df -h /dev/shm`、shared-memory 使用量、worker exit reason |
-| GPU device count vs 可用算力／VRAM | `CUDA_VISIBLE_DEVICES` 顯示一張 GPU | [NVIDIA time-slicing](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html#understanding-time-slicing-gpus) 只共享時間，沒有 MIG 等級的 memory/fault isolation；其他 sharing layer 也可能另有 VRAM/core contract | Pod 看得到 GPU 卻 OOM、latency 抖動，或兩個 workload 互相拖慢 | 明確選擇 exclusive、MIG、time-slicing 或 vendor vGPU；不要把「1 GPU」當成固定算力與 VRAM | per-process VRAM、SM utilization、allocator peak、Xid/OOM、sharing mode |
-| CPU/NUMA/GPU locality | Runtime 看到所有 CPUs 與一張可見 GPU | CPU、RAM 與 PCIe GPU 可能跨 NUMA node | Host utilization 正常但 H2D、tokenization 或 input pipeline latency 高且不穩 | 需要時使用 Topology Manager、CPU Manager/cpuset，並驗證 memory locality；不要只做 CPU pinning | NUMA miss、PCIe throughput、CPU affinity、GPU topology、phase latency |
-| Container writable layer vs 模型／checkpoint 大小 | Application 把 `/tmp`、HF cache、Torch cache 視為一般磁碟 | ephemeral-storage limit、node disk pressure、image pull/unpack 與 log 也競爭本機磁碟 | `Evicted`、`ENOSPC`、啟動或 checkpoint 變慢，重啟後 cache 消失 | 模型與大型 cache 放明確 volume；配置 ephemeral request/limit、清理與水位告警 | volume/rootfs bytes、inode、ephemeral-storage events、pull/unpack latency |
-| Runtime spinning vs 真實工作量 | Runtime 為降低單次延遲讓 idle worker spin | 多個模型／session 共用 CPU 時，spinning 會消耗 quota 與電力 | 沒有請求仍有固定 CPU，其他服務 p95 上升 | 依 latency/throughput 目標關閉或縮短 spinning；不要僅看單 request benchmark | idle CPU、power、session/thread 數、p50/p99、throttled time |
+| CPU topology vs CPU quota | Host logical/physical CPUs, affinity, or the runtime's default thread count | cgroup CPU quota/period | Node is idle, but Pod latency spikes periodically and `throttled` keeps increasing | Set intra-op, inter-op, OMP, MKL, and OpenBLAS from the effective CPU budget; measure before tuning | [`cpu.stat` and CPU limit](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#how-kubernetes-applies-resource-requests-and-limits), throttled ratio/time, run queue, phase latency, runtime thread count |
+| Process count × thread pool | Every worker assumes it can use the full CPU | All workers share one Pod/cgroup quota | More workers reduce throughput while context switches and load surge | Choose process concurrency first, then divide the total CPU budget among per-process thread pools | Process/thread count, context switches, CPU PSI, per-worker throughput |
+| CPU request vs limit vs exclusive cores | The application usually sees runnable CPUs but does not understand Kubernetes QoS | Request affects scheduling and contention weight; limit is a hard ceiling; exclusive CPUs also require static CPU Manager, a Guaranteed Pod, and an integer CPU request | Identical Pods have different latency across nodes or interfere with sidecars and host processes | Consider Guaranteed QoS plus static CPU Manager only for latency-sensitive workloads; otherwise first set correct requests and limits | Pod QoS, cpuset, CPU Manager policy, steal/throttling, node noise |
+| Host RAM vs cgroup memory | A runtime, cache, or allocator may plan from host RAM | Pod memory limit; tmpfs `emptyDir` may also count toward container memory | Node appears to have RAM, but the Pod is `OOMKilled`; page cache, model cache, or tmpfs expands the working set | Size cache, batch, and prefetch from the cgroup memory budget; set `sizeLimit` on memory-backed volumes | Working set/RSS, cgroup memory events, OOM reason, tmpfs/cache bytes |
+| `/dev/shm` vs DataLoader/IPC demand | Multiprocessing assumes sufficient POSIX shared memory | [Docker defaults `/dev/shm` to 64 MiB](https://docs.docker.com/engine/containers/run/#runtime-constraints-on-resources); Kubernetes volume configuration is separate | DataLoader bus errors, NCCL/IPC initialization failures, or failures only at large batch sizes | Explicitly configure a memory-backed `emptyDir` or runtime shm size and include it in memory capacity planning | `df -h /dev/shm`, shared-memory usage, worker exit reason |
+| GPU device count vs available compute/VRAM | `CUDA_VISIBLE_DEVICES` exposes one GPU | [NVIDIA time-slicing](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html#understanding-time-slicing-gpus) shares time only and lacks MIG-level memory/fault isolation; other sharing layers may define separate VRAM/core contracts | A Pod sees a GPU but OOMs, has unstable latency, or slows another workload | Explicitly choose exclusive GPU, MIG, time-slicing, or vendor vGPU; do not treat “1 GPU” as fixed compute and VRAM | Per-process VRAM, SM utilization, allocator peak, Xid/OOM, sharing mode |
+| CPU/NUMA/GPU locality | The runtime sees all CPUs and one visible GPU | CPU, RAM, and PCIe GPU may reside on different NUMA nodes | Host utilization looks normal, but H2D, tokenization, or input-pipeline latency is high and unstable | Use Topology Manager and CPU Manager/cpuset when needed, then verify memory locality; CPU pinning alone is insufficient | NUMA misses, PCIe throughput, CPU affinity, GPU topology, phase latency |
+| Container writable layer vs model/checkpoint size | The application treats `/tmp`, HF cache, and Torch cache as ordinary disk | Ephemeral-storage limit, node disk pressure, image pulls/unpacking, and logs compete for local disk | `Evicted`, `ENOSPC`, slow startup/checkpointing, or cache loss after restart | Put models and large caches on explicit volumes; set ephemeral requests/limits, cleanup, and watermarks | Volume/rootfs bytes, inodes, ephemeral-storage events, pull/unpack latency |
+| Runtime spinning vs real workload | The runtime keeps idle workers spinning to reduce single-request latency | With multiple models or sessions sharing CPU, spinning consumes quota and power | Fixed CPU usage without requests and increased p95 for other services | Disable or shorten spinning according to latency/throughput goals; do not rely on a single-request benchmark | Idle CPU, power, session/thread count, p50/p99, throttled time |
 
-表中的控制方式不是可以直接複製的固定模板。例如 Kubernetes static CPU Manager 只有在
-節點正確設定，且 container 位於 Guaranteed Pod、具有整數 CPU request 時，才會分配
-exclusive CPUs（見 [Kubernetes CPU Manager](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy-configuration)）。GPU time-slicing 也不等同 VRAM 隔離；NVIDIA 文件明確指出它沒有
-memory 或 fault isolation。
+These controls are not fixed templates that can be copied unchanged. For example, Kubernetes static CPU Manager allocates exclusive CPUs only when the node is configured correctly and the container belongs to a Guaranteed Pod with an integer CPU request; see [Kubernetes CPU Manager](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy-configuration). GPU time-slicing likewise does not provide VRAM isolation; NVIDIA explicitly documents the absence of memory and fault isolation.
 
-## 常見 ML runtime 的 CPU 控制面
+## CPU Controls for Common ML Runtimes
 
-| Runtime／library | 主要控制方式 | 常見陷阱 |
+| Runtime/library | Primary controls | Common trap |
 | --- | --- | --- |
-| PyTorch | `OMP_NUM_THREADS`、`MKL_NUM_THREADS`、`torch.set_num_threads()`、`torch.set_num_interop_threads()` | 必須在 eager/JIT/autograd 工作開始前設定；總 process threads 不會等於數值計算 threads |
-| NumPy + BLAS | `OMP_NUM_THREADS`、OpenBLAS/MKL 對應變數，或 `threadpoolctl` | NumPy 本身常是單 thread，但背後 BLAS 可以另外開多 thread |
-| TensorFlow | `tf.config.threading.set_intra_op_parallelism_threads()`、`set_inter_op_parallelism_threads()` | `tf.data`、serving workers 與 operator thread pools 可能形成多層平行 |
-| ONNX Runtime | `intra_op_num_threads`、`inter_op_num_threads`、execution mode、thread spinning 設定 | [預設 intra-op pool 可依 physical cores 建立](https://onnxruntime.ai/docs/performance/tune-performance/threading.html#intra-thread-count)；多個 session 會重複建立 pool |
-| DataLoader／multiprocessing | process/worker 數、prefetch、每個 child 的 BLAS/PyTorch threads | `workers × threads` 才是總 CPU 壓力；fork/spawn 行為與共享記憶體也要納入 |
-| Serving engine | request concurrency、batch/token budget、CPU preprocess workers | GPU batch 調大不代表 CPU tokenizer、音訊編碼、publisher 有足夠容量 |
+| PyTorch | `OMP_NUM_THREADS`, `MKL_NUM_THREADS`, `torch.set_num_threads()`, `torch.set_num_interop_threads()` | Configure them before eager, JIT, or autograd work begins; total process threads do not equal numerical-compute threads |
+| NumPy + BLAS | `OMP_NUM_THREADS`, the corresponding OpenBLAS/MKL variables, or `threadpoolctl` | NumPy itself is often single-threaded while the underlying BLAS opens additional threads |
+| TensorFlow | `tf.config.threading.set_intra_op_parallelism_threads()`, `set_inter_op_parallelism_threads()` | `tf.data`, serving workers, and operator pools may create multiple layers of parallelism |
+| ONNX Runtime | `intra_op_num_threads`, `inter_op_num_threads`, execution mode, thread-spinning settings | [The default intra-op pool may be sized from physical cores](https://onnxruntime.ai/docs/performance/tune-performance/threading.html#intra-thread-count); multiple sessions create repeated pools |
+| DataLoader/multiprocessing | Process/worker count, prefetch, per-child BLAS/PyTorch threads | `workers × threads` is the total CPU pressure; fork/spawn behavior and shared memory also matter |
+| Serving engine | Request concurrency, batch/token budget, CPU preprocessing workers | A larger GPU batch does not guarantee sufficient capacity in CPU tokenization, audio encoding, or publishing |
 
-設定環境變數要早於 NumPy、PyTorch 或會載入 BLAS/OpenMP 的套件 import。只在模型載入後
-修改，可能已經建立 thread pool，結果依 runtime 而異。
+Set environment variables before importing NumPy, PyTorch, or any package that loads BLAS/OpenMP. Changing them only after the model loads may be too late because the runtime may already have created its thread pools.
 
 ```python
 import os
 
-# 這個數字應由 deployment 的 effective CPU budget 注入，不應硬編碼成所有服務共用值。
+# The deployment should inject this effective CPU budget; do not hard-code one value for every service.
 threads = int(os.environ["ML_CPU_THREADS"])
 for name in ("OMP_NUM_THREADS", "MKL_NUM_THREADS", "OPENBLAS_NUM_THREADS", "NUMEXPR_NUM_THREADS"):
     os.environ[name] = str(threads)
@@ -94,8 +78,7 @@ torch.set_num_threads(threads)
 torch.set_num_interop_threads(min(2, threads))
 ```
 
-Kubernetes 可以用 [`resourceFieldRef`](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api) 把 container CPU limit 以 millicores 注入 entrypoint，
-再由 entrypoint 轉成有上下界的 thread budget：
+Kubernetes can inject the container CPU limit in millicores through [`resourceFieldRef`](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api). The entrypoint can then convert it into a bounded thread budget:
 
 ```yaml
 resources:
@@ -114,57 +97,47 @@ env:
         divisor: 1m
 ```
 
-應用仍要驗證值存在、可解析並落在 release 支援的範圍；不要讓缺少 limit 變成 0 threads，
-也不要看到 64 host CPUs 就自動採用 64。若 Pod 有 sidecar，每個 container 的 budget 與整個
-Pod 的 QoS/資源總和都必須分別核對。
+The application must still validate that the value exists, parses correctly, and falls within a release-supported range. A missing limit must not become zero threads, and seeing 64 host CPUs must not automatically select 64 threads. If a Pod has sidecars, verify both each container's budget and the total Pod QoS/resources.
 
-## 診斷順序：從「哪一層在等」開始
+## Diagnostic Order: Start with Which Phase Is Waiting
 
-1. **拆 phase timer。** 將 normalization、tokenizer、H2D、model forward、postprocess、encode、
-   publish 分開量測；只有 end-to-end latency 無法區分 CPU、GPU、I/O 或 queue。
-2. **同時看 node 與 cgroup。** Node idle 不會否定 container throttling；Node busy 也不代表
-   該 request 一定在 CPU 上。
-3. **讀 effective CPU。** 比較 affinity/cpuset 與 quota/period。可用的平行度上界概念上是：
+1. **Instrument phase timers.** Measure normalization, tokenization, H2D, model forward, postprocessing, encoding, and publishing separately. End-to-end latency alone cannot distinguish CPU, GPU, I/O, or queue delay.
+2. **Observe node and cgroup together.** Node idle does not disprove container throttling; node busy does not prove that a request is executing on CPU.
+3. **Read the effective CPU budget.** Compare affinity/cpuset with quota/period. Conceptually, the upper bound on parallelism is:
 
    ```text
    effective_cpu = min(cpuset_cpu_count, cpu_quota / cpu_period)
    ```
 
-   quota 若為 unlimited，才只看 cpuset/affinity。fractional CPU 需要以 benchmark 決定 thread
-   數，不能直接把小數無條件進位。
-4. **列出所有 thread pools。** 除了 framework，還要包含 BLAS、tokenizer、DataLoader、web
-   server、Celery/Ray workers、ffmpeg 與 sidecar。
-5. **做相同輸入 A/B。** 固定 model、input、batch、GPU profile 與同機競爭 workload，只改
-   thread budget；比較 throughput、p50/p95/p99、throttling 與輸出品質。
-6. **保留 watchdog 與 stack。** phase 超時時輸出所有 thread stack，再由 orchestrator 重啟；
-   restart 是止血，不是根因證明。
+   Only when quota is unlimited should cpuset/affinity be used alone. Fractional CPU needs benchmarking to choose a thread count; do not unconditionally round it up.
+4. **Inventory every thread pool.** Include BLAS, tokenizers, DataLoaders, web servers, Celery/Ray workers, ffmpeg, and sidecars in addition to the framework.
+5. **Run a same-input A/B test.** Hold model, input, batch, GPU profile, and colocated competing workloads constant. Change only the thread budget, then compare throughput, p50/p95/p99, throttling, and output quality.
+6. **Preserve watchdog evidence and stacks.** On a phase timeout, emit all thread stacks before the orchestrator restarts the process. Restarting is mitigation, not proof of root cause.
 
-對 cgroup v2，`cpu.stat` 的 `nr_periods`、`nr_throttled`、`throttled_usec` 與 `cpu.max` 是重要
-證據；cgroup v1 使用對應的 `cpu.stat`、`cpu.cfs_quota_us` 與 `cpu.cfs_period_us`。監控系統可能
-以不同 metric 名稱暴露相同資料，runbook 應保存實際查詢，而不是只寫 dashboard 截圖。
+For cgroup v2, `nr_periods`, `nr_throttled`, and `throttled_usec` in `cpu.stat`, plus `cpu.max`, are important evidence. cgroup v1 exposes the corresponding `cpu.stat`, `cpu.cfs_quota_us`, and `cpu.cfs_period_us`. Monitoring systems may publish the same data under different metric names, so a runbook should preserve the actual queries rather than only dashboard screenshots.
 
-## Production checklist
+## Production Checklist
 
-- [ ] Deployment 明確宣告 CPU/memory requests 與 limits。
-- [ ] Application thread budget 來自 effective CPU，而不是 host CPU count。
-- [ ] `process concurrency × threads per process` 不超出經 benchmark 證明的容量。
-- [ ] Phase metrics、cgroup throttling、OOM、GPU allocated/reserved 與 queue age 可觀測。
-- [ ] `/dev/shm`、tmpfs、ephemeral storage、model cache 與 checkpoint 有容量上限。
-- [ ] GPU sharing 模式、VRAM/fault isolation 與 workload request 語意一致。
-- [ ] Latency-sensitive Pod 若要求 exclusive CPU，已驗證 QoS、整數 request、CPU Manager 與 NUMA。
-- [ ] 相同輸入做過冷啟動、穩態、並發與同機 noisy-neighbor A/B。
-- [ ] watchdog 能指出停滯 phase；重啟後任務具 checkpoint、冪等與安全重試。
+- [ ] The Deployment explicitly declares CPU/memory requests and limits.
+- [ ] The application thread budget comes from effective CPU, not the host CPU count.
+- [ ] `process concurrency × threads per process` stays within benchmarked capacity.
+- [ ] Phase metrics, cgroup throttling, OOMs, GPU allocated/reserved memory, and queue age are observable.
+- [ ] `/dev/shm`, tmpfs, ephemeral storage, model cache, and checkpoints have capacity limits.
+- [ ] GPU sharing mode, VRAM/fault isolation, and workload request semantics agree.
+- [ ] A latency-sensitive Pod requesting exclusive CPU has verified QoS, integer request, CPU Manager, and NUMA configuration.
+- [ ] Same-input A/B tests cover cold start, steady state, concurrency, and colocated noisy neighbors.
+- [ ] The watchdog identifies the stalled phase; restarted tasks support checkpoints, idempotency, and safe retries.
 
-## 參考資料
+## References
 
-- [Kubernetes：Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
-- [Kubernetes：Control CPU Management Policies on the Node](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/)
-- [PyTorch：Threading Environment Variables](https://docs.pytorch.org/docs/stable/threading_environment_variables.html)
-- [PyTorch：CPU threading and TorchScript inference](https://docs.pytorch.org/docs/stable/notes/cpu_threading_torchscript_inference.html)
-- [PyTorch：`torch.set_num_threads`](https://docs.pytorch.org/docs/stable/generated/torch.set_num_threads.html)
-- [NumPy：Number of threads used for linear algebra](https://numpy.org/doc/stable/reference/global_state.html#number-of-threads-used-for-linear-algebra)
-- [TensorFlow：Configure intra-op parallelism](https://www.tensorflow.org/api_docs/python/tf/config/threading/set_intra_op_parallelism_threads)
-- [TensorFlow：Configure inter-op parallelism](https://www.tensorflow.org/api_docs/python/tf/config/threading/set_inter_op_parallelism_threads)
-- [ONNX Runtime：Thread management](https://onnxruntime.ai/docs/performance/tune-performance/threading.html)
-- [Docker：Runtime constraints on resources](https://docs.docker.com/engine/containers/run/#runtime-constraints-on-resources)
-- [NVIDIA GPU Operator：Time-Slicing GPUs in Kubernetes](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html)
+- [Kubernetes: Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+- [Kubernetes: Control CPU Management Policies on the Node](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/)
+- [PyTorch: Threading Environment Variables](https://docs.pytorch.org/docs/stable/threading_environment_variables.html)
+- [PyTorch: CPU threading and TorchScript inference](https://docs.pytorch.org/docs/stable/notes/cpu_threading_torchscript_inference.html)
+- [PyTorch: `torch.set_num_threads`](https://docs.pytorch.org/docs/stable/generated/torch.set_num_threads.html)
+- [NumPy: Number of threads used for linear algebra](https://numpy.org/doc/stable/reference/global_state.html#number-of-threads-used-for-linear-algebra)
+- [TensorFlow: Configure intra-op parallelism](https://www.tensorflow.org/api_docs/python/tf/config/threading/set_intra_op_parallelism_threads)
+- [TensorFlow: Configure inter-op parallelism](https://www.tensorflow.org/api_docs/python/tf/config/threading/set_inter_op_parallelism_threads)
+- [ONNX Runtime: Thread management](https://onnxruntime.ai/docs/performance/tune-performance/threading.html)
+- [Docker: Runtime constraints on resources](https://docs.docker.com/engine/containers/run/#runtime-constraints-on-resources)
+- [NVIDIA GPU Operator: Time-Slicing GPUs in Kubernetes](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html)

--- a/mlops/container-resource-awareness/README.md
+++ b/mlops/container-resource-awareness/README.md
@@ -5,9 +5,6 @@
 > Updated: 2026-08-28
 
 In Kubernetes, a model may be assigned only 8 CPUs while PyTorch, OpenMP, MKL, ONNX Runtime, or data-preprocessing code creates far more than 8 threads. Node monitoring may even show substantial idle CPU while inference inside the Pod remains intermittent and latency spikes.
-
-This does not mean the libraries truly bypass the Pod to obtain additional resources. More precisely:
-
 - **Resource discovery** may observe host CPUs, physical cores, CPU affinity, or a library's own defaults and size a thread pool from that information.
 - **Resource enforcement** still applies Kubernetes CPU and memory limits through Linux cgroups.
 - Oversubscription occurs when discovery and enforcement disagree about the budget available to the same workload.

--- a/mlops/container-resource-awareness/README.zh-TW.md
+++ b/mlops/container-resource-awareness/README.zh-TW.md
@@ -6,10 +6,7 @@
 
 在 Kubernetes 裡，模型明明只被配置 8 CPU，PyTorch、OpenMP、MKL、ONNX Runtime
 或資料前處理程序卻可能建立遠多於 8 個執行緒。節點監控甚至可能顯示大量 CPU
-idle，但 Pod 內的推論仍斷斷續續、延遲暴增。
-
-這不是套件真的「繞過 Pod」取得額外資源。更精確的說法是：
-
+idle，但 Pod 內的推論仍斷斷續續、延遲暴增:
 - **資源偵測（discovery）**可能看到 host CPU、physical cores、CPU affinity 或套件自己的
   預設值，並據此建立 thread pool。
 - **資源執法（enforcement）**仍由 Linux cgroup 執行 Kubernetes 的 CPU、memory 等限制。

--- a/mlops/container-resource-awareness/README.zh-TW.md
+++ b/mlops/container-resource-awareness/README.zh-TW.md
@@ -1,0 +1,172 @@
+# 容器內 ML workload 的資源感知：別把 host-visible 當成 Pod budget
+
+> [English](./README.md) | **繁體中文**
+
+> 更新日期：2026-08-28
+
+在 Kubernetes 裡，模型明明只被配置 8 CPU，PyTorch、OpenMP、MKL、ONNX Runtime
+或資料前處理程序卻可能建立遠多於 8 個執行緒。節點監控甚至可能顯示大量 CPU
+idle，但 Pod 內的推論仍斷斷續續、延遲暴增。
+
+這不是套件真的「繞過 Pod」取得額外資源。更精確的說法是：
+
+- **資源偵測（discovery）**可能看到 host CPU、physical cores、CPU affinity 或套件自己的
+  預設值，並據此建立 thread pool。
+- **資源執法（enforcement）**仍由 Linux cgroup 執行 Kubernetes 的 CPU、memory 等限制。
+- discovery 與 enforcement 對同一 workload 的預算理解不同，就會發生 oversubscription。
+
+Kubernetes [明確說明 CPU limit 是由 kernel throttling 強制執行](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits)；它不是 thread pool
+大小，也不會自動替每個 ML runtime 選出合理的平行度。因此，`resources.limits.cpu: 8`
+不能取代 `OMP_NUM_THREADS=8`、`torch.set_num_threads(8)` 或相應 runtime 設定。
+
+## 為什麼全機 CPU idle，Pod 還是會被 throttle
+
+假設節點有 128 cores，Pod 的 CPU limit 是 8。以常見的 100 ms CFS period 為例，
+該 Pod 在每個 period 共有約 800 ms 的 aggregate CPU time：
+
+- 8 個持續工作的 threads 可以把預算均勻用完整個 100 ms。
+- 64 個 threads 理論上約 12.5 ms 就能一起用完 800 ms，之後整個 cgroup 等待下一個 period。
+- 其餘約 120 個 host cores 即使保持 idle，也不能借給已碰到 hard limit 的 Pod。
+
+對 BERT 這種包含許多小型 operator、barrier 與逐句呼叫的路徑，quota burst 還會疊加：
+
+- OpenMP、MKL、OpenBLAS、PyTorch intra-op/inter-op 各自建立或喚醒 worker。
+- 多個 Python worker、DataLoader 或 serving process 再乘上一層 thread pool。
+- context switch、cache thrashing 與 thread-pool spinning 消耗預算。
+- barrier 只要等到一個被延後的 worker，整個 operator 就無法完成。
+
+所以限制 thread 數後變快，不代表「thread 越少越好」；它代表**有效平行度終於和
+cgroup 可用預算對齊**。
+
+一個實際案例中，約 128-core 節點上的 TTS Pod 限制為 8 CPU，程序總 thread 數約
+273。cgroup 觀察到 82 個 throttled periods，以及約 417 秒的累積 throttled time；舊路徑
+處理 85 句 BERT 曾耗時約 14 分 54 秒。將 PyTorch/BLAS 的數值計算 thread pools 對齊
+8 CPU 後，另一筆真實 workload 的 73 句前處理約 7 秒，單次 BERT forward 多數約
+25–40 ms。
+
+這不是嚴格控制所有變因的 benchmark，不能據此宣稱每個模型都應固定設成 8；但它證明
+了兩件事：全機 idle 不能排除 Pod throttling，而且 thread budget 必須是 workload contract
+的一部分。歷史慢請求發生時尚無 phase-level watchdog，因此不能回溯宣稱某一個 BERT
+operator 是唯一根因。
+
+## 業界常見資源認知落差比較表
+
+| 落差 | 套件／程序常看到什麼 | 實際限制或競爭點 | 常見症狀 | 優先處理方式 | 應觀測的證據 |
+| --- | --- | --- | --- | --- | --- |
+| CPU topology vs CPU quota | Host logical/physical CPU、affinity，或 runtime 預設 thread 數 | cgroup CPU quota/period | 節點 idle 但 Pod latency 呈週期性尖峰、`throttled` 持續增加 | 以 effective CPU budget 設定 intra-op、inter-op、OMP、MKL、OpenBLAS；先量測再調整 | [`cpu.stat` 與 CPU limit](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#how-kubernetes-applies-resource-requests-and-limits)、throttled ratio/time、run queue、phase latency、runtime thread 數 |
+| Process 數 × thread pool | 每個 worker 都認為自己可使用完整 CPU | 所有 workers 共用同一 Pod/cgroup quota | worker 增加後吞吐不升反降，context switches 與 load 暴增 | 先決定 process concurrency，再把每個 process 的 thread budget 分配到總 CPU 預算內 | process/thread 數、context switches、CPU PSI、每 worker throughput |
+| CPU request vs limit vs exclusive cores | Application 通常只知道可執行 CPU，不理解 Kubernetes QoS | request 影響排程與競爭權重；limit 是 hard ceiling；exclusive CPU 還需要 static CPU Manager、Guaranteed Pod 與整數 CPU request | 同規格 Pod 在不同節點 latency 差異大，與 sidecar/host process 互相干擾 | latency-sensitive workload 才評估 Guaranteed + static CPU Manager；一般 workload 先正確配置 request/limit | Pod QoS、cpuset、CPU Manager policy、steal/throttling、node noise |
+| Host RAM vs cgroup memory | Runtime、cache 或 allocator 可能依 host RAM 規劃 | Pod memory limit、tmpfs `emptyDir` 也可能計入 container memory | Node 看似有 RAM，但 Pod `OOMKilled`；page cache、模型 cache 或 tmpfs 推高 working set | 以 cgroup memory budget 設 cache、batch、prefetch；為 memory-backed volume 設 `sizeLimit` | working set/RSS、cgroup memory events、OOM reason、tmpfs/cache bytes |
+| `/dev/shm` vs DataLoader/IPC 需求 | multiprocessing 假設有足夠 POSIX shared memory | [Docker 預設 `/dev/shm` 只有 64 MiB](https://docs.docker.com/engine/containers/run/#runtime-constraints-on-resources)；Kubernetes volume 配置另行決定 | DataLoader bus error、NCCL/IPC 初始化失敗、大 batch 才偶發 | 明確配置 memory-backed `emptyDir` 或 runtime shm size，並把它納入 memory capacity | `df -h /dev/shm`、shared-memory 使用量、worker exit reason |
+| GPU device count vs 可用算力／VRAM | `CUDA_VISIBLE_DEVICES` 顯示一張 GPU | [NVIDIA time-slicing](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html#understanding-time-slicing-gpus) 只共享時間，沒有 MIG 等級的 memory/fault isolation；其他 sharing layer 也可能另有 VRAM/core contract | Pod 看得到 GPU 卻 OOM、latency 抖動，或兩個 workload 互相拖慢 | 明確選擇 exclusive、MIG、time-slicing 或 vendor vGPU；不要把「1 GPU」當成固定算力與 VRAM | per-process VRAM、SM utilization、allocator peak、Xid/OOM、sharing mode |
+| CPU/NUMA/GPU locality | Runtime 看到所有 CPUs 與一張可見 GPU | CPU、RAM 與 PCIe GPU 可能跨 NUMA node | Host utilization 正常但 H2D、tokenization 或 input pipeline latency 高且不穩 | 需要時使用 Topology Manager、CPU Manager/cpuset，並驗證 memory locality；不要只做 CPU pinning | NUMA miss、PCIe throughput、CPU affinity、GPU topology、phase latency |
+| Container writable layer vs 模型／checkpoint 大小 | Application 把 `/tmp`、HF cache、Torch cache 視為一般磁碟 | ephemeral-storage limit、node disk pressure、image pull/unpack 與 log 也競爭本機磁碟 | `Evicted`、`ENOSPC`、啟動或 checkpoint 變慢，重啟後 cache 消失 | 模型與大型 cache 放明確 volume；配置 ephemeral request/limit、清理與水位告警 | volume/rootfs bytes、inode、ephemeral-storage events、pull/unpack latency |
+| Runtime spinning vs 真實工作量 | Runtime 為降低單次延遲讓 idle worker spin | 多個模型／session 共用 CPU 時，spinning 會消耗 quota 與電力 | 沒有請求仍有固定 CPU，其他服務 p95 上升 | 依 latency/throughput 目標關閉或縮短 spinning；不要僅看單 request benchmark | idle CPU、power、session/thread 數、p50/p99、throttled time |
+
+表中的控制方式不是可以直接複製的固定模板。例如 Kubernetes static CPU Manager 只有在
+節點正確設定，且 container 位於 Guaranteed Pod、具有整數 CPU request 時，才會分配
+exclusive CPUs（見 [Kubernetes CPU Manager](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy-configuration)）。GPU time-slicing 也不等同 VRAM 隔離；NVIDIA 文件明確指出它沒有
+memory 或 fault isolation。
+
+## 常見 ML runtime 的 CPU 控制面
+
+| Runtime／library | 主要控制方式 | 常見陷阱 |
+| --- | --- | --- |
+| PyTorch | `OMP_NUM_THREADS`、`MKL_NUM_THREADS`、`torch.set_num_threads()`、`torch.set_num_interop_threads()` | 必須在 eager/JIT/autograd 工作開始前設定；總 process threads 不會等於數值計算 threads |
+| NumPy + BLAS | `OMP_NUM_THREADS`、OpenBLAS/MKL 對應變數，或 `threadpoolctl` | NumPy 本身常是單 thread，但背後 BLAS 可以另外開多 thread |
+| TensorFlow | `tf.config.threading.set_intra_op_parallelism_threads()`、`set_inter_op_parallelism_threads()` | `tf.data`、serving workers 與 operator thread pools 可能形成多層平行 |
+| ONNX Runtime | `intra_op_num_threads`、`inter_op_num_threads`、execution mode、thread spinning 設定 | [預設 intra-op pool 可依 physical cores 建立](https://onnxruntime.ai/docs/performance/tune-performance/threading.html#intra-thread-count)；多個 session 會重複建立 pool |
+| DataLoader／multiprocessing | process/worker 數、prefetch、每個 child 的 BLAS/PyTorch threads | `workers × threads` 才是總 CPU 壓力；fork/spawn 行為與共享記憶體也要納入 |
+| Serving engine | request concurrency、batch/token budget、CPU preprocess workers | GPU batch 調大不代表 CPU tokenizer、音訊編碼、publisher 有足夠容量 |
+
+設定環境變數要早於 NumPy、PyTorch 或會載入 BLAS/OpenMP 的套件 import。只在模型載入後
+修改，可能已經建立 thread pool，結果依 runtime 而異。
+
+```python
+import os
+
+# 這個數字應由 deployment 的 effective CPU budget 注入，不應硬編碼成所有服務共用值。
+threads = int(os.environ["ML_CPU_THREADS"])
+for name in ("OMP_NUM_THREADS", "MKL_NUM_THREADS", "OPENBLAS_NUM_THREADS", "NUMEXPR_NUM_THREADS"):
+    os.environ[name] = str(threads)
+
+import torch
+
+torch.set_num_threads(threads)
+torch.set_num_interop_threads(min(2, threads))
+```
+
+Kubernetes 可以用 [`resourceFieldRef`](https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api) 把 container CPU limit 以 millicores 注入 entrypoint，
+再由 entrypoint 轉成有上下界的 thread budget：
+
+```yaml
+resources:
+  requests:
+    cpu: "8"
+    memory: 32Gi
+  limits:
+    cpu: "8"
+    memory: 32Gi
+env:
+  - name: CONTAINER_CPU_LIMIT_MILLICORES
+    valueFrom:
+      resourceFieldRef:
+        containerName: inference
+        resource: limits.cpu
+        divisor: 1m
+```
+
+應用仍要驗證值存在、可解析並落在 release 支援的範圍；不要讓缺少 limit 變成 0 threads，
+也不要看到 64 host CPUs 就自動採用 64。若 Pod 有 sidecar，每個 container 的 budget 與整個
+Pod 的 QoS/資源總和都必須分別核對。
+
+## 診斷順序：從「哪一層在等」開始
+
+1. **拆 phase timer。** 將 normalization、tokenizer、H2D、model forward、postprocess、encode、
+   publish 分開量測；只有 end-to-end latency 無法區分 CPU、GPU、I/O 或 queue。
+2. **同時看 node 與 cgroup。** Node idle 不會否定 container throttling；Node busy 也不代表
+   該 request 一定在 CPU 上。
+3. **讀 effective CPU。** 比較 affinity/cpuset 與 quota/period。可用的平行度上界概念上是：
+
+   ```text
+   effective_cpu = min(cpuset_cpu_count, cpu_quota / cpu_period)
+   ```
+
+   quota 若為 unlimited，才只看 cpuset/affinity。fractional CPU 需要以 benchmark 決定 thread
+   數，不能直接把小數無條件進位。
+4. **列出所有 thread pools。** 除了 framework，還要包含 BLAS、tokenizer、DataLoader、web
+   server、Celery/Ray workers、ffmpeg 與 sidecar。
+5. **做相同輸入 A/B。** 固定 model、input、batch、GPU profile 與同機競爭 workload，只改
+   thread budget；比較 throughput、p50/p95/p99、throttling 與輸出品質。
+6. **保留 watchdog 與 stack。** phase 超時時輸出所有 thread stack，再由 orchestrator 重啟；
+   restart 是止血，不是根因證明。
+
+對 cgroup v2，`cpu.stat` 的 `nr_periods`、`nr_throttled`、`throttled_usec` 與 `cpu.max` 是重要
+證據；cgroup v1 使用對應的 `cpu.stat`、`cpu.cfs_quota_us` 與 `cpu.cfs_period_us`。監控系統可能
+以不同 metric 名稱暴露相同資料，runbook 應保存實際查詢，而不是只寫 dashboard 截圖。
+
+## Production checklist
+
+- [ ] Deployment 明確宣告 CPU/memory requests 與 limits。
+- [ ] Application thread budget 來自 effective CPU，而不是 host CPU count。
+- [ ] `process concurrency × threads per process` 不超出經 benchmark 證明的容量。
+- [ ] Phase metrics、cgroup throttling、OOM、GPU allocated/reserved 與 queue age 可觀測。
+- [ ] `/dev/shm`、tmpfs、ephemeral storage、model cache 與 checkpoint 有容量上限。
+- [ ] GPU sharing 模式、VRAM/fault isolation 與 workload request 語意一致。
+- [ ] Latency-sensitive Pod 若要求 exclusive CPU，已驗證 QoS、整數 request、CPU Manager 與 NUMA。
+- [ ] 相同輸入做過冷啟動、穩態、並發與同機 noisy-neighbor A/B。
+- [ ] watchdog 能指出停滯 phase；重啟後任務具 checkpoint、冪等與安全重試。
+
+## 參考資料
+
+- [Kubernetes：Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+- [Kubernetes：Control CPU Management Policies on the Node](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/)
+- [PyTorch：Threading Environment Variables](https://docs.pytorch.org/docs/stable/threading_environment_variables.html)
+- [PyTorch：CPU threading and TorchScript inference](https://docs.pytorch.org/docs/stable/notes/cpu_threading_torchscript_inference.html)
+- [PyTorch：`torch.set_num_threads`](https://docs.pytorch.org/docs/stable/generated/torch.set_num_threads.html)
+- [NumPy：Number of threads used for linear algebra](https://numpy.org/doc/stable/reference/global_state.html#number-of-threads-used-for-linear-algebra)
+- [TensorFlow：Configure intra-op parallelism](https://www.tensorflow.org/api_docs/python/tf/config/threading/set_intra_op_parallelism_threads)
+- [TensorFlow：Configure inter-op parallelism](https://www.tensorflow.org/api_docs/python/tf/config/threading/set_inter_op_parallelism_threads)
+- [ONNX Runtime：Thread management](https://onnxruntime.ai/docs/performance/tune-performance/threading.html)
+- [Docker：Runtime constraints on resources](https://docs.docker.com/engine/containers/run/#runtime-constraints-on-resources)
+- [NVIDIA GPU Operator：Time-Slicing GPUs in Kubernetes](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html)

--- a/mlops/tts-inference-performance-tuning/README.md
+++ b/mlops/tts-inference-performance-tuning/README.md
@@ -1,0 +1,208 @@
+# Layer-by-Layer TTS Inference Tuning: BERT Transfers, Batching, and Checkpoint Boundaries
+
+> **English** | [繁體中文](./README.zh-TW.md)
+
+Updated: 2026-08-29
+
+This field note records a sequence of production-shaped GPT-SoVITS experiments on an NVIDIA L40S. It is not a universal tuning recipe. Its main result is that TTS throughput is controlled by several different boundaries, and changing the wrong one can trade recoverability or VRAM for little speed:
+
+```text
+business task
+  -> outer request/checkpoint chunks
+    -> sentence-aware internal segments
+      -> inference batches
+        -> text normalization and BERT
+          -> GPT + VITS
+            -> MP3 parts and bounded-memory join
+```
+
+The best measured configuration in this case combined roughly 50-character sentence-aware internal segments, batch 32, and a single outer request for inputs that fit a measured VRAM budget. Long inputs still need outer checkpoints. Separately, keeping BERT feature expansion on GPU was a low-risk micro-optimization, while batching BERT forwards produced a smaller end-to-end gain and a higher observed peak.
+
+## Four Controls That Must Not Be Confused
+
+| Control | What it changes | Primary benefit | Primary risk |
+| --- | --- | --- | --- |
+| Outer request/checkpoint size | How much business text is sent through one API request | Fewer round trips, repeated prompt work, cache cleanup, MP3 joins | Higher failure replay cost and higher single-request VRAM |
+| Internal segment target | Sentence-aware text pieces seen by the inference engine | More uniform sequence shapes and less padding waste | Too many tiny segments add frontend overhead; large targets create uneven batches |
+| TTS inference batch | Number of internal segments processed together | Fewer GPU rounds and higher GPU utilization | Larger activation peak and diminishing returns in tail batches |
+| BERT batch | Number of cleaned text segments tokenized and forwarded together | Fewer tokenizer/BERT calls | Padding and a higher transient peak; mixed-language paths need explicit fallback |
+
+`batch_size=32` does not mean 32 characters, 32 business tasks, or 32 outer chunks. In these experiments it meant up to 32 internal text segments in one inference round. The production worker still used one business task at a time; it did not dynamically combine segments from unrelated requests.
+
+## Experimental Contract
+
+The experiments used completed real inputs but did not reclaim or update their database rows. Before each intrusive A/B:
+
+1. The production consumer stopped claiming new work and drained the current task naturally.
+2. Input text, replacement rules, voice/reference audio, fine-tuned models, generation parameters, and the inference runtime were held constant unless named as the independent variable.
+3. The probe called the inference endpoint directly and wrote only private test outputs.
+4. Wall time, target-process VRAM, total GPU VRAM, output duration, clipping/impulse metrics, and service restarts were recorded.
+5. The temporary configuration was removed and the production consumer was shown to complete real work again.
+
+Some early runs reused an already-warm legacy process, so raw `nvidia-smi` values include model state and allocator cache. Peak values are therefore reported as observed process working sets, not model size. Values from different experiment windows should not be subtracted unless they share the same baseline and sampling method.
+
+## Experiment 1: Internal Segment Targets of 50, 100, and 500 Characters
+
+A 4,611-character input was run with batch 32. Each variant was repeated twice. The target is sentence-aware: it accumulates complete sentences around the target instead of blindly cutting at exactly the Nth character.
+
+| Internal target | Median latency | Maximum observed TTS-process peak | Output duration |
+| ---: | ---: | ---: | ---: |
+| 50 characters | 31.423 s | 12,616 MiB | 808.416 s |
+| 100 characters | 33.630 s | 11,240 MiB | 808.956 s |
+| 500 characters | 33.220 s | 23,544 MiB | 787.356 s |
+
+The 500-character target did not improve latency, nearly doubled the observed peak relative to target 50, and changed output duration much more. The likely mechanism is sequence-shape imbalance: a batch waits for its longest sequence and pads shorter members, while autoregressive and attention work grows with sequence length. More characters per segment do not automatically mean better GPU saturation.
+
+Target 50 was retained for this workload. This is an empirical value, not a generic default for every voice model, language, punctuation distribution, or GPU.
+
+## Experiment 2: TTS Batch 4, 16, and 32
+
+The next A/B used the same 4,109-character input and the same three sequential outer chunks of 1,987, 1,999, and 123 characters. Internal splitting remained at roughly 50 characters and `parallel_infer=true`; only TTS batch changed.
+
+Before the batch sweep, enabling per-request parallel inference at batch 4 reduced the complete probe from approximately 201.042 to 101.421 seconds: 49.55% less time. The three outer requests were still sequential; parallelism existed inside each request, not across checkpoint chunks.
+
+| Batch | End-to-end inference + join | Relative to batch 4 | Observed process peak | Notes |
+| ---: | ---: | ---: | ---: | --- |
+| 4 | 101.421 s | baseline | 17,080 MiB | Parallel inference already enabled |
+| 16 | 36.960 s | 2.744× faster | 17,592 MiB | 63.56% less time |
+| 32 | 31.325 s | 3.238× faster | 15,704 MiB | 15.25% faster than batch 16 |
+
+The batch-32 raw peak appears lower because the warm process reused cached allocator blocks and one-second `nvidia-smi` sampling can miss sub-second allocations. It is not evidence that batch 32 intrinsically needs less VRAM than batch 16.
+
+For this input, 123 short segments required ten GPU rounds at batch 16 and six rounds at batch 32. The final 123-character outer chunk contained only four internal segments, so its tail batch could not use the larger capacity. This explains the diminishing gain from 16 to 32.
+
+A direct comparison against the legacy parameters used one outer request, batch 35, and a four-sentence split:
+
+| Path | Latency | Observed process peak | Internal batch shape |
+| --- | ---: | ---: | --- |
+| Legacy-shaped request | 21.097 s | 24,036 MiB | approximately `[35, 35, 35, 3]` |
+| 50-character segments, batch 32 | 18.586 s | 24,870 MiB | `[32, 32, 32, 31]` |
+
+The smaller batch was 11.90% faster because the segments were more uniform and the tail batch was fuller. Batch capacity is only useful when the sequence shapes and final occupancy allow it to be used.
+
+## Experiment 3: Outer 2,000-Character Checkpoints vs One Request
+
+Outer chunks provide durable progress: after each successful chunk, an implementation can persist an MP3 part and checksum so a later failure does not replay the whole document. However, each boundary repeats request setup, prompt/reference handling, frontend work, response transfer, and final MP3 joining.
+
+Two independent real-input A/Bs measured this cost.
+
+| Input | Before | After | Result | VRAM evidence |
+| --- | --- | --- | --- | --- |
+| 4,109 characters | three outer requests, batch 32: 31.325 s | one outer request, batch 32: 18.586 s | 40.66% less time | single request peaked at 24,870 MiB |
+| 4,611 characters, fixed seed, two repetitions | three outer requests: median 33.174 s | one outer request: median 24.123 s | 27.3% less time | observed peak rose from 7,684 to 13,038 MiB |
+
+The second experiment used an interleaved order—outer, single, single, outer—to reduce warm-up and ordering bias. All four outputs passed the offline clipping and impulse detector. The outer and single outputs differed in duration by 0.90%, so fixed seed did not make the two execution graphs byte-identical.
+
+The production candidate policy from this evidence is adaptive:
+
+- Inputs no larger than about 5,000 characters may use one outer request only when the selected GPU profile has measured headroom.
+- Longer inputs retain bounded outer chunks and durable per-chunk checkpoints.
+- A failed chunk resumes from a verified checkpoint; it does not concatenate every decoded MP3 into Python memory.
+- The threshold belongs to the application release profile and corpus benchmark, not to cluster IaC.
+
+This preserves fast execution for common medium-length inputs without giving up bounded replay for genuinely long documents.
+
+## Experiment 4: Keep BERT Phone Expansion on GPU
+
+The inherited BERT path first moved character-level hidden states to CPU, expanded every character in a Python loop, and later moved the result back to GPU:
+
+```python
+# Before: device transfer, Python list growth, then another transfer downstream.
+res = hidden_states.cpu()
+phone_level = torch.cat([
+    res[index].repeat(repeat_count, 1)
+    for index, repeat_count in enumerate(word2ph)
+])
+```
+
+The revised path keeps the tensor on its existing device and performs one vectorized expansion:
+
+```python
+# After: preserve order and dtype on the current device.
+repeat_counts = torch.as_tensor(word2ph, device=res.device, dtype=torch.long)
+phone_level = torch.repeat_interleave(
+    res,
+    repeat_counts,
+    dim=0,
+    output_size=sum(word2ph),
+)
+```
+
+| Microbenchmark input | CPU/Python expansion | Device-local `repeat_interleave` | Interpretation |
+| --- | ---: | ---: | --- |
+| Representative 50-character segment, p50 | 0.4945 ms | 0.3232 ms | about 0.17 ms saved per segment |
+| 2,000-character synthetic expansion | 16.04 ms | 0.4146 ms | removes Python-loop scaling and transfer overhead |
+
+For roughly 70 short segments, the direct saving was only about 12 ms, so this change alone cannot explain multi-second end-to-end gains. Its value is low-risk cleanup of an unnecessary device round trip and a poor long-sequence scaling path. It should be validated for exact row order, dtype, device, and phone count before deployment.
+
+## Experiment 5: Batch BERT Forwards
+
+The sequential path still invoked tokenizer and BERT once per cleaned segment. An experimental path grouped up to 32 plain-Chinese segments, padded them, ran one BERT forward, then reconstructed each row using its attention mask and `word2ph`. Mixed-language or unsupported input fell back to the existing sequential path.
+
+The original 4,611-character test contained Latin letters and correctly took the fallback, so it was not used to claim a batching result. A separate completed 4,144-character all-Chinese input was tested twice with the same model, voice, seed, batch 32, and one outer request.
+
+| Metric | Sequential BERT | Batched BERT, max 32 | Change |
+| --- | ---: | ---: | ---: |
+| Two runs | 22.002 / 22.055 s | 21.625 / 19.659 s | — |
+| Median latency | 22.029 s | 20.642 s | 6.3% faster |
+| Maximum observed TTS-process peak | 20,628 MiB | 22,798 MiB | +2,170 MiB, or 10.5% |
+| Output duration | 743.256 s | 741.744 s | -0.20% |
+| Integrated loudness | -25.4 LUFS | -25.4 LUFS | unchanged |
+
+Runtime phase logs proved that the request entered `batch-model-forward` rather than fallback. It formed five BERT forwards per request. Both outputs had zero hard clips, near clips, or excessive adjacent sample steps.
+
+This is a promising but smaller gain than the outer-boundary and TTS-batch changes. It should remain configurable until a corpus covers short/long text, punctuation distributions, mixed languages, cold/warm state, and colocated GPU load.
+
+## Post-Experiment Production Snapshot
+
+After removing the temporary BERT override and restoring the worker and scheduler, the TTS Pod had restart count zero and completed real database work again. A one-hour snapshot recorded:
+
+| Completed tasks | Characters | Mean processing time | P50 | P90 |
+| ---: | ---: | ---: | ---: | ---: |
+| 89 | 381,773 | 35.80 s | 37.00 s | 41.00 s |
+
+The direct A/B requests were read-only and did not update business rows, so they were not included in these production counts. This snapshot proves recovery and useful throughput after the experiment; it does not by itself attribute all production throughput to one optimization.
+
+## What the Experiments Support
+
+| Decision | Current evidence | Recommended status |
+| --- | --- | --- |
+| Keep BERT phone expansion on GPU | Exact operation replacement plus focused microbenchmark | Low-risk default after source and tensor-contract tests |
+| Use sentence-aware target near 50 characters | Faster and much lower peak than target 500 in the measured input | Workload default, still configurable |
+| Use TTS batch 32 | Strong gain from 4→16 and smaller gain from 16→32 | Default only with a matching VRAM profile |
+| Disable parallel inference after any retry | Historical retry count did not identify GPU pressure | Do not do this; downgrade only for release-scoped OOM/timeout evidence |
+| One outer request for every document | Fast for 4–5K characters but raises replay and VRAM risk | Reject as a universal rule |
+| Adaptive single request below a measured threshold | Reproduced 27–41% latency reduction | Good candidate; keep checkpoints above the threshold |
+| Batch BERT forwards | 6.3% median gain with 10.5% higher observed peak in one all-Chinese case | Opt-in experiment pending broader regression |
+
+## A Reproducible Tuning Order
+
+1. **Instrument phases first.** Separate language detection, normalization, tokenizer, BERT, GPT, VITS, download, encode, join, and publish time.
+2. **Fix correctness and hidden I/O.** Model downloads, cache misses, language-model loading, and retry races can dominate any kernel optimization.
+3. **Bound CPU threads.** Match PyTorch/BLAS thread pools to the effective Pod CPU budget; see [Resource-Aware ML Workloads in Containers](../container-resource-awareness/).
+4. **Remove unnecessary transfers.** Prove device, dtype, order, and shape equivalence with a focused test.
+5. **Tune internal segment shape.** Compare latency, padding/round count, peak VRAM, duration, and acoustic artifacts.
+6. **Sweep TTS batch within a fixed outer plan.** Do not compare batch values while also changing chunking or concurrency.
+7. **Then tune the outer boundary.** Measure the speed/replay/VRAM trade-off and retain checkpoints above a validated threshold.
+8. **Experiment with frontend batching.** BERT batching is a separate optimization with separate padding and language-routing risks.
+9. **Run production-shaped validation.** Include cold/warm state, retry, OOM recovery, mixed workloads, audio quality, DB publication, and rollback.
+
+## Metrics That Prevent Misleading Conclusions
+
+- Report per-run values and medians, not only the fastest run.
+- Identify whether GPU memory is process working set, allocator allocated/reserved, or scheduler reservation.
+- Record sampling interval; one-second `nvidia-smi` can miss transient peaks.
+- Hold outer chunks, internal split, batch, parallel mode, model, seed, and colocated load constant unless they are the tested variable.
+- Validate duration, clipping, impulse/join artifacts, loudness, F0, and a spectral proxy; use listening and task-specific intelligibility checks as well.
+- Treat MFCC cosine and pitch similarity as diagnostics, not speaker identity or semantic equivalence.
+- Verify that the consumer resumes real work with no OOM, timeout, traceback, or restart after the experiment.
+
+## Limitations
+
+- The strongest tables use two real inputs of about 4K–4.6K characters on one L40S and one voice/model family.
+- Some historical runs were randomized; fixed-seed repetitions were added later but do not cover the whole matrix.
+- Different VRAM tables came from different warm allocator states and sampling rates, so only within-window comparisons are valid.
+- The BERT-batching result covers an all-Chinese path. Mixed-language batching was intentionally not claimed.
+- These experiments did not implement cross-request continuous batching. That would require queue fairness, cancellation, per-request reconstruction, and latency-SLO design.
+
+The reusable lesson is not “always choose 50, 32, and 5,000.” It is to tune each layer independently, preserve failure recovery where it matters, and promote a setting only with same-input latency, resource, quality, and recovery evidence.

--- a/mlops/tts-inference-performance-tuning/README.zh-TW.md
+++ b/mlops/tts-inference-performance-tuning/README.zh-TW.md
@@ -1,0 +1,248 @@
+# 逐層調教 TTS 推論：BERT 搬運、batch 與 checkpoint 邊界
+
+> [English](./README.md) | **繁體中文**
+
+更新日期：2026-08-29
+
+這篇實務筆記整理一系列在 NVIDIA L40S 上、貼近 production 的 GPT-SoVITS 實驗；它不是所有
+TTS 都能直接複製的參數表。核心結論是：TTS 吞吐同時受好幾種邊界控制，改錯旋鈕可能犧牲
+可恢復性或 VRAM，卻只換到很小的速度收益：
+
+```text
+業務任務
+  -> 外層 request／checkpoint 分片
+    -> 保留句界的內部分段
+      -> inference batches
+        -> 文字正規化與 BERT
+          -> GPT + VITS
+            -> MP3 parts 與 bounded-memory 合併
+```
+
+這個案例目前量到的最佳組合，是約 50 字且保留完整句界的內部分段、batch 32，以及在實測
+VRAM 預算容許時，讓中等長度輸入只走一個外層 request。真正的長文仍需保留外層 checkpoint。
+另一條線上，將 BERT feature expansion 留在 GPU 是低風險微調；批次執行 BERT forward 則有較小
+的端到端收益，也觀察到較高峰值。
+
+## 四個不能混為一談的控制面
+
+| 控制面 | 改變什麼 | 主要收益 | 主要風險 |
+| --- | --- | --- | --- |
+| 外層 request／checkpoint 大小 | 一次 API request 放多少業務文字 | 減少 round trip、重複 prompt 工作、cache cleanup 與 MP3 join | 單次失敗重算更多，單 request VRAM 較高 |
+| 內部分段目標 | 推論引擎看到的句界感知文字片段 | sequence shape 更均勻、減少 padding 浪費 | 太碎會增加 frontend overhead；太長會形成不均勻 batch |
+| TTS inference batch | 同時處理多少內部分段 | 減少 GPU rounds、提高利用率 | activation peak 上升，尾批效益遞減 |
+| BERT batch | 同時 tokenize 並 forward 多少 clean text segments | 減少 tokenizer／BERT 呼叫次數 | padding 與 transient peak；混合語言必須明確 fallback |
+
+`batch_size=32` 不代表 32 個字、32 筆業務任務或 32 個外層 chunk；在這些實驗裡，它是一次
+inference round 最多處理 32 個內部文字片段。Production worker 仍一次處理一筆業務任務，沒有
+把不同 request 的片段動態混成 continuous batch。
+
+## 實驗契約
+
+實驗使用已完成的真實輸入，但不重新 claim 或更新其 DB row。每次會影響 runtime 的 A/B 前：
+
+1. Production consumer 先停止領新工作，讓當前任務自然 drain。
+2. 除了被測變因，固定輸入、replace rules、voice/reference、fine-tuned models、生成參數與 runtime。
+3. Probe 直接呼叫 inference endpoint，只寫入私有測試輸出。
+4. 記錄 wall time、目標 process VRAM、整卡 VRAM、音訊長度、clipping／impulse 與 service restart。
+5. 移除暫時配置，再確認 production consumer 能繼續完成真實工作。
+
+早期部分實驗重用了已 warm 的 legacy process，因此 `nvidia-smi` raw value 包含模型 working set
+與 allocator cache。本文將它稱為觀察到的 process working set，不稱為模型大小。不同測試窗口
+若沒有相同 baseline 與採樣方法，不能直接互相相減。
+
+## 實驗一：內部分段目標 50、100、500 字
+
+使用一筆 4,611 字輸入與 batch 32，每個變體重複兩次。這個目標會累積完整句子到門檻附近，
+不是機械式在第 N 個字硬切。
+
+| 內部分段目標 | 延遲中位數 | TTS process 觀察最大峰值 | 輸出長度 |
+| ---: | ---: | ---: | ---: |
+| 50 字 | 31.423 s | 12,616 MiB | 808.416 s |
+| 100 字 | 33.630 s | 11,240 MiB | 808.956 s |
+| 500 字 | 33.220 s | 23,544 MiB | 787.356 s |
+
+500 字不但沒有變快，觀察峰值接近 50 字版本的兩倍，輸出長度差異也大得多。最合理的機制是
+sequence shape 不均：一個 batch 會等最長序列，短序列還要 padding；autoregressive 與 attention
+成本也會隨序列長度增加。每段字數增加，不等於 GPU 一定更飽和。
+
+因此這個 workload 保留 50 字目標；它是實驗值，不是所有 voice model、語言、標點分布或 GPU
+的通用預設。
+
+## 實驗二：TTS batch 4、16、32
+
+使用相同 4,109 字輸入，外層固定為依序執行的 1,987／1,999／123 字三段；內部分段保持約
+50 字、`parallel_infer=true`，只改 TTS batch。
+
+在 batch sweep 前，先固定 batch 4 比較 per-request parallel inference；完整 probe 由約
+201.042 秒降至 101.421 秒，時間減少 49.55%。三個外層 requests 仍是串行；parallelism 發生在
+每個 request 內部，不會跨 checkpoint chunks 同時執行。
+
+| Batch | 推論加合併端到端時間 | 相對 batch 4 | Process 觀察峰值 | 備註 |
+| ---: | ---: | ---: | ---: | --- |
+| 4 | 101.421 s | baseline | 17,080 MiB | 已啟用 parallel inference |
+| 16 | 36.960 s | 快 2.744× | 17,592 MiB | 時間減少 63.56% |
+| 32 | 31.325 s | 快 3.238× | 15,704 MiB | 比 batch 16 再快 15.25% |
+
+Batch 32 的 raw peak 看起來反而較低，是因為 warm process 重用了 allocator blocks，而且一秒一次
+的 `nvidia-smi` 可能漏掉次秒配置；這不是 batch 32 天生比 batch 16 省 VRAM 的證據。
+
+該輸入形成 123 個短片段：batch 16 需要十輪 GPU batch，batch 32 需要六輪。最後 123 字的
+外層 chunk 只有四個短片段，再大的 batch 也用不到，這解釋 16→32 的邊際效益已明顯下降。
+
+另一輪直接重現 legacy 參數：單一外層 request、batch 35、每四句切一次：
+
+| 路徑 | 延遲 | Process 觀察峰值 | 內部 batch shape |
+| --- | ---: | ---: | --- |
+| Legacy-shaped request | 21.097 s | 24,036 MiB | 約 `[35, 35, 35, 3]` |
+| 50 字分段、batch 32 | 18.586 s | 24,870 MiB | `[32, 32, 32, 31]` |
+
+較小的 batch 反而快 11.90%，因為片段 shape 更均勻，尾批也更滿。Batch 容量只有在 sequence
+shape 與最後一批 occupancy 允許時才有價值。
+
+## 實驗三：外層 2,000 字 checkpoint vs 單一 request
+
+外層分片可保存 durable progress：每完成一段就保存 MP3 part 與 checksum，後段失敗不用全文
+重產。但每個邊界都會重複 request setup、prompt/reference 處理、frontend、response transfer 與
+最終 MP3 join。
+
+兩組獨立真實輸入 A/B 量出這個成本：
+
+| 輸入 | 前測 | 後測 | 結果 | VRAM 證據 |
+| --- | --- | --- | --- | --- |
+| 4,109 字 | 三個外層 requests、batch 32：31.325 s | 一個外層 request、batch 32：18.586 s | 時間減少 40.66% | 單一 request 峰值 24,870 MiB |
+| 4,611 字、固定 seed、各兩次 | 三個外層 requests：中位 33.174 s | 一個外層 request：中位 24.123 s | 時間減少 27.3% | 觀察峰值由 7,684 升至 13,038 MiB |
+
+第二組採用 outer、single、single、outer 的交錯順序，降低 warm-up 與順序偏差。四個輸出都通過
+離線 clipping／impulse detector；outer 與 single 的音訊長度差 0.90%，所以 fixed seed 也不代表
+兩種 execution graph 會 byte-identical。
+
+目前證據支持的 production candidate policy 是自適應：
+
+- 約 5,000 字內，且所選 GPU profile 有實測 headroom 時，可走單一外層 request。
+- 更長輸入保留 bounded outer chunks 與 durable per-chunk checkpoints。
+- 某段失敗時從驗證過的 checkpoint 繼續；不要把所有 decoded MP3 累積在 Python memory。
+- 門檻屬於 application release profile 與 corpus benchmark，不屬於 cluster IaC。
+
+這能讓常見中等長度輸入走快路徑，又不犧牲真正長文的 bounded replay。
+
+## 實驗四：讓 BERT phone expansion 留在 GPU
+
+繼承的 BERT 路徑先把 character-level hidden states 搬到 CPU，在 Python loop 逐字展開，後面又搬回
+GPU：
+
+```python
+# Before：device transfer、Python list growth，後面還要再 transfer。
+res = hidden_states.cpu()
+phone_level = torch.cat([
+    res[index].repeat(repeat_count, 1)
+    for index, repeat_count in enumerate(word2ph)
+])
+```
+
+修正版把 tensor 留在原 device，用一次向量化操作展開：
+
+```python
+# After：在原 device 保留順序與 dtype。
+repeat_counts = torch.as_tensor(word2ph, device=res.device, dtype=torch.long)
+phone_level = torch.repeat_interleave(
+    res,
+    repeat_counts,
+    dim=0,
+    output_size=sum(word2ph),
+)
+```
+
+| Microbenchmark 輸入 | CPU／Python 展開 | Device-local `repeat_interleave` | 解讀 |
+| --- | ---: | ---: | --- |
+| 代表性 50 字片段，p50 | 0.4945 ms | 0.3232 ms | 每段約省 0.17 ms |
+| 2,000 字 synthetic expansion | 16.04 ms | 0.4146 ms | 移除 Python-loop scaling 與 transfer overhead |
+
+約 70 個短片段的直接收益只有約 12 ms，所以這項修改本身不能解釋數秒的端到端差異。它的價值
+是用低風險方式移除不必要的 device round trip 與長序列下很差的 Python scaling。部署前仍要驗證
+row order、dtype、device 與 phone count 完全一致。
+
+## 實驗五：批次 BERT forward
+
+逐句版本仍會為每個 clean segment 各做一次 tokenizer 與 BERT forward。實驗版把最多 32 個
+純中文 segments 一起 padding、做一次 BERT forward，再依 attention mask 與 `word2ph` 重建每列；
+混合語言或不支援的輸入會 fallback 到既有逐句路徑。
+
+原本 4,611 字測試含拉丁字母，正確走 fallback，因此沒有拿它冒充 batch 結果。另選一筆已完成的
+4,144 字全中文輸入，在相同 model、voice、seed、batch 32 與單一外層 request 下各跑兩次：
+
+| 指標 | 逐句 BERT | 批次 BERT，上限 32 | 差異 |
+| --- | ---: | ---: | ---: |
+| 兩次耗時 | 22.002 / 22.055 s | 21.625 / 19.659 s | — |
+| 延遲中位數 | 22.029 s | 20.642 s | 快 6.3% |
+| TTS process 最大觀察峰值 | 20,628 MiB | 22,798 MiB | +2,170 MiB，或 10.5% |
+| 音訊長度 | 743.256 s | 741.744 s | -0.20% |
+| Integrated loudness | -25.4 LUFS | -25.4 LUFS | 相同 |
+
+Runtime phase log 證明請求真的進入 `batch-model-forward`，而不是 fallback；每個 request 形成五次
+BERT forwards。兩側都沒有 hard clip、near clip 或超門檻相鄰 sample step。
+
+這個收益有潛力，但小於外層邊界與 TTS batch 的收益。正式設為 default 前應維持可配置，並用
+短／長文、不同標點、混合語言、cold／warm 狀態與 colocated GPU load 做 corpus regression。
+
+## 實驗後的 production 快照
+
+移除暫時 BERT override 並恢復 worker／scheduler 後，TTS Pod restart count 為 0，且重新完成真實
+DB 工作。最近一小時快照為：
+
+| 完成任務 | 字數 | 平均處理時間 | P50 | P90 |
+| ---: | ---: | ---: | ---: | ---: |
+| 89 | 381,773 | 35.80 s | 37.00 s | 41.00 s |
+
+直接 A/B request 只讀且不更新業務 row，因此不計入 production 完成量。這份快照證明實驗後已
+恢復並具有實際吞吐；它本身不能把全部 production throughput 歸因給某一項優化。
+
+## 實驗目前支持哪些決策
+
+| 決策 | 當前證據 | 建議狀態 |
+| --- | --- | --- |
+| BERT phone expansion 留在 GPU | Exact operation replacement 與 focused microbenchmark | 通過 source/tensor contract 測試後可作低風險預設 |
+| 句界感知目標約 50 字 | 此輸入比 500 字快，峰值也低很多 | Workload 預設，但保持可配置 |
+| TTS batch 32 | 4→16 大幅提升，16→32 仍有較小收益 | 只在匹配的 VRAM profile 下作預設 |
+| 任一 retry 就關掉 parallel inference | 歷史 retry count 無法代表 GPU 壓力 | 不應採用；只依 release-scoped OOM／timeout 證據降級 |
+| 所有文件都走一個外層 request | 4–5K 字很快，但 replay 與 VRAM 風險上升 | 拒絕作通用規則 |
+| 實測門檻以下走自適應單 request | 兩組實驗重現 27–41% latency reduction | 好的候選；門檻以上保留 checkpoints |
+| 批次 BERT forward | 一筆全中文案例快 6.3%，觀察峰值高 10.5% | 擴大回歸前維持 opt-in |
+
+## 可重現的調教順序
+
+1. **先拆 phase timer。** 分開量 language detection、normalization、tokenizer、BERT、GPT、VITS、
+   download、encode、join 與 publish。
+2. **先修 correctness 與 hidden I/O。** 模型下載、cache miss、language-model loading 與 retry race
+   足以淹沒任何 kernel optimization。
+3. **限制 CPU threads。** 讓 PyTorch／BLAS thread pools 對齊 Pod effective CPU budget；見
+   [容器內 ML workload 的資源感知](../container-resource-awareness/README.zh-TW.md)。
+4. **移除不必要的 transfer。** 用 focused test 證明 device、dtype、order、shape 等價。
+5. **調整內部分段 shape。** 同時比較 latency、padding／round 數、peak VRAM、duration 與音訊 artifact。
+6. **固定外層計畫後掃 TTS batch。** 不要一邊改 batch、一邊改 chunking 或 concurrency。
+7. **最後才調外層邊界。** 量化 speed／replay／VRAM trade-off，在門檻以上保留 checkpoints。
+8. **實驗 frontend batching。** BERT batching 是獨立優化，有自己的 padding 與語言 routing 風險。
+9. **跑 production-shaped validation。** 包含 cold／warm、retry、OOM recovery、混合 workload、
+   音訊品質、DB publication 與 rollback。
+
+## 避免錯誤結論的量測項目
+
+- 報告每輪數值與中位數，不只挑最快的一輪。
+- 說清楚 GPU memory 是 process working set、allocator allocated/reserved，還是 scheduler reservation。
+- 記錄採樣間隔；一秒一次的 `nvidia-smi` 可能漏掉 transient peak。
+- 除被測變因外，固定 outer chunks、internal split、batch、parallel mode、model、seed 與 colocated load。
+- 驗證 duration、clipping、impulse／join artifact、loudness、F0 與頻譜代理，也要人工耳聽與做任務專屬
+  intelligibility check。
+- MFCC cosine 與 pitch similarity 只是診斷，不等於聲紋身分或語意等價。
+- 實驗後確認 consumer 能繼續完成真實工作，且沒有 OOM、timeout、traceback 或 restart。
+
+## 限制
+
+- 最完整的表格只涵蓋兩筆約 4K–4.6K 字真實輸入、一張 L40S 與一個 voice/model family。
+- 部分歷史實驗仍有隨機性；後續補了 fixed-seed repetitions，但沒有覆蓋整個矩陣。
+- 各 VRAM 表格來自不同 allocator warm state 與採樣頻率，只有同一窗口內的比較有效。
+- BERT batching 只驗證全中文路徑；本文刻意不宣稱混合語言已通過。
+- 實驗尚未實作 cross-request continuous batching；那需要 queue fairness、cancellation、逐 request
+  reconstruction 與 latency SLO 設計。
+
+真正可複用的 lesson 不是「永遠選 50、32、5,000」，而是分層隔離變因、在需要的地方保留失敗
+恢復，並只用相同輸入的 latency、資源、品質與 recovery 證據提升某個設定。


### PR DESCRIPTION
## 摘要

- 說明 ML runtime 的資源偵測與 Kubernetes cgroup 執法為不同控制面，避免誤稱套件「繞過 Pod」
- 以實際 CPU quota/thread oversubscription 案例解釋為何 node idle 時 Pod 仍可能 throttle
- 整理 CPU、memory、`/dev/shm`、GPU sharing、NUMA、ephemeral storage 與 runtime spinning 的常見落差
- 新增 GPT-SoVITS 雙語調教實驗：
  - BERT CPU round-trip → device-local `repeat_interleave`
  - 逐句 BERT → batched BERT
  - 50／100／500 字內部分段 A/B
  - TTS batch 4／16／32 與 `parallel_infer` A/B
  - 外層 2,000 字 checkpoint → 量測門檻內單一 request
  - 音訊品質、VRAM、恢復性與最近一小時 production throughput 證據
- 補上可重現調教順序、決策表、量測陷阱與限制；不把單一 L40S／voice 的數值當通用預設
- 更新英文與繁體中文 MLOps 索引

## 主要實驗結果

- Batch 4 → 16 → 32：`101.421s → 36.960s → 31.325s`
- 4,109 字，外層三段 → 單一 request：`31.325s → 18.586s`
- 4,611 字 fixed-seed 複驗：中位 `33.174s → 24.123s`，但 peak VRAM 上升
- BERT phone expansion microbenchmark：50 字 p50 `0.4945ms → 0.3232ms`
- 4,144 字全中文 batched-BERT：中位 `22.029s → 20.642s`，觀察 peak 增加 10.5%
- 實驗後一小時 production 快照：89 筆、381,773 字、P50/P90 `37/41s`

## 驗證

- `npx --yes markdownlint-cli --disable MD013 -- mlops/README.md mlops/README.zh-TW.md mlops/tts-inference-performance-tuning/README.md mlops/tts-inference-performance-tuning/README.zh-TW.md`
- `npx --yes markdown-link-check mlops/tts-inference-performance-tuning/README.md`
- `npx --yes markdown-link-check mlops/tts-inference-performance-tuning/README.zh-TW.md`
- 雙語 17 組關鍵實驗數字 parity 檢查通過
- 相對連結與敏感識別碼檢查通過
- `git diff --check` 通過

## 知識來源與邊界

通用容器結論以 Kubernetes、PyTorch、NumPy、TensorFlow、ONNX Runtime、Docker 與 NVIDIA 官方文件核對。TTS 章節來自 2026-08-26 至 2026-08-29 的 production-shaped、DB-read-only A/B；已匿名化 task、主機、IP、voice 與模型路徑。MFCC、F0、clipping 與 loudness 是診斷證據，不宣稱聲紋身分或全 corpus 語意等價。
